### PR TITLE
feat: support multiple serializer interfaces (as_crm_payload | to_h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ end
 # app/serializers/etlify/user_serializer.rb
 class UserSerializer < Etlify::Serializers::BaseSerializer
   # Must return a Hash that matches your CRM field names
+  # you can also use to_h method
   def as_crm_payload(user)
     {
       email: user.email,

--- a/lib/etlify/model.rb
+++ b/lib/etlify/model.rb
@@ -64,9 +64,9 @@ module Etlify
       serializer = self.class.etlify_serializer.new(self)
 
       if serializer.respond_to?(:as_crm_payload)
-        serializer.public_send(:as_crm_payload)
+        serializer.as_crm_payload
       elsif serializer.respond_to?(:to_h)
-        serializer.public_send(:to_h)
+        serializer.to_h
       else
         raise NoMethodError, "#{serializer.class} must implement \"as_crm_payload\" or \"to_h\""
       end

--- a/lib/etlify/model.rb
+++ b/lib/etlify/model.rb
@@ -61,7 +61,15 @@ module Etlify
     def build_crm_payload
       raise_unless_crm_is_configured
 
-      self.class.etlify_serializer.new(self).as_crm_payload
+      serializer = self.class.etlify_serializer.new(self)
+
+      if serializer.respond_to?(:as_crm_payload)
+        serializer.public_send(:as_crm_payload)
+      elsif serializer.respond_to?(:to_h)
+        serializer.public_send(:to_h)
+      else
+        raise NoMethodError, "#{serializer.class} must implement \"as_crm_payload\" or \"to_h\""
+      end
     end
 
     # @param async [Boolean, nil] prioritaire sur la config globale

--- a/lib/etlify/model.rb
+++ b/lib/etlify/model.rb
@@ -63,12 +63,10 @@ module Etlify
 
       serializer = self.class.etlify_serializer.new(self)
 
-      if serializer.respond_to?(:as_crm_payload)
-        serializer.as_crm_payload
-      elsif serializer.respond_to?(:to_h)
+      if serializer.respond_to?(:to_h)
         serializer.to_h
-      else
-        raise NoMethodError, "#{serializer.class} must implement \"as_crm_payload\" or \"to_h\""
+      else serializer.respond_to?(:as_crm_payload)
+        serializer.as_crm_payload
       end
     end
 

--- a/spec/models/etlify_model_spec.rb
+++ b/spec/models/etlify_model_spec.rb
@@ -133,15 +133,15 @@ RSpec.describe Etlify::Model do
     end
 
     it "falls back to to_h when as_crm_payload is not implemented" do
-      rec = TestUserToH.create!(email: "toh@example.com", full_name: "To H")
-      payload = rec.build_crm_payload
-      expect(payload).to include(id: rec.id, email: "toh@example.com", source: "to_h")
+      user = TestUserToH.create!(email: "toh@example.com", full_name: "To H")
+      payload = user.build_crm_payload
+      expect(payload).to include(id: user.id, email: "toh@example.com", source: "to_h")
     end
 
     it "raises an error if neither as_crm_payload nor to_h are implemented" do
-      rec = TestUserNoPayload.create!(email: "nopayload@example.com", full_name: "No Payload")
+      user = TestUserNoPayload.create!(email: "nopayload@example.com", full_name: "No Payload")
       expect {
-        rec.build_crm_payload
+        user.build_crm_payload
       }.to raise_error(NoMethodError, /must implement "as_crm_payload" or "to_h"/)
     end
 

--- a/spec/models/etlify_model_spec.rb
+++ b/spec/models/etlify_model_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Etlify::Model do
           { id: record.id, email: record.email }
         end
       end
+
+      class TestUserToHSerializer < BaseSerializer
+        def to_h
+          { id: record.id, email: record.email }
+        end
+      end
+
+      class TestUserNoPayloadSerializer < BaseSerializer
+      end
     end
   end
 
@@ -26,6 +35,40 @@ RSpec.describe Etlify::Model do
 
     etlified_with(
       serializer: Etlify::Serializers::TestUserSerializer,
+      crm_object_type: "contacts",
+      id_property: :id,
+      sync_if: ->(u) { u.email.present? }
+    )
+
+    def crm_object_type
+      "contacts"
+    end
+  end
+
+  class TestUserToH < ActiveRecord::Base
+    self.table_name = "users"
+    include Etlify::Model
+    belongs_to :company, optional: true
+
+    etlified_with(
+      serializer: Etlify::Serializers::TestUserToHSerializer,
+      crm_object_type: "contacts",
+      id_property: :id,
+      sync_if: ->(u) { u.email.present? }
+    )
+
+    def crm_object_type
+      "contacts"
+    end
+  end
+
+  class TestUserNoPayload < ActiveRecord::Base
+    self.table_name = "users"
+    include Etlify::Model
+    belongs_to :company, optional: true
+
+    etlified_with(
+      serializer: Etlify::Serializers::TestUserNoPayloadSerializer,
       crm_object_type: "contacts",
       id_property: :id,
       sync_if: ->(u) { u.email.present? }
@@ -87,6 +130,19 @@ RSpec.describe Etlify::Model do
     it "uses the configured serializer and returns a stable Hash" do
       payload = user.build_crm_payload
       expect(payload).to include(id: user.id, email: "john@example.com")
+    end
+
+    it "falls back to to_h when as_crm_payload is not implemented" do
+      rec = TestUserToH.create!(email: "toh@example.com", full_name: "To H")
+      payload = rec.build_crm_payload
+      expect(payload).to include(id: rec.id, email: "toh@example.com", source: "to_h")
+    end
+
+    it "raises an error if neither as_crm_payload nor to_h are implemented" do
+      rec = TestUserNoPayload.create!(email: "nopayload@example.com", full_name: "No Payload")
+      expect {
+        rec.build_crm_payload
+      }.to raise_error(NoMethodError, /must implement "as_crm_payload" or "to_h"/)
     end
 
     it "raises an error if crm_synced is not configured (documentation test)", :aggregate_failures do

--- a/spec/models/etlify_model_spec.rb
+++ b/spec/models/etlify_model_spec.rb
@@ -135,14 +135,14 @@ RSpec.describe Etlify::Model do
     it "falls back to to_h when as_crm_payload is not implemented" do
       user = TestUserToH.create!(email: "toh@example.com", full_name: "To H")
       payload = user.build_crm_payload
-      expect(payload).to include(id: user.id, email: "toh@example.com", source: "to_h")
+      expect(payload).to include(id: user.id, email: "toh@example.com")
     end
 
     it "raises an error if neither as_crm_payload nor to_h are implemented" do
       user = TestUserNoPayload.create!(email: "nopayload@example.com", full_name: "No Payload")
       expect {
         user.build_crm_payload
-      }.to raise_error(NoMethodError, /must implement "as_crm_payload" or "to_h"/)
+      }.to raise_error(NotImplementedError)
     end
 
     it "raises an error if crm_synced is not configured (documentation test)", :aggregate_failures do


### PR DESCRIPTION
Pour l'implémentation on a utilisé des Dictionnaires pour serializer.

Et dans la plupart des app, on utilise la méthode `to_h` pour les dictionnaires.

Je propose qu'on aille aussi checker la méthode `to_h` pour les serializers.

Aussi j'ai rajouté une erreur si on ne trouve ni l'un (as_crm_payload) ni l'autre (to_h)