### PR TITLE
docs: add upgrade guide for 0.9.3 and 0.9.4

### DIFF
--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -1,3 +1,149 @@
+# UPGRADING FROM 0.9.3 -> 0.9.4
+
+## 1. Overview
+
+Etlify 0.9.4 introduces three new features and two bug fixes:
+
+**New features:**
+
+- **`stale_scope`** — Restrict which records the `StaleRecords::Finder` considers at SQL level
+- **`error_count`** — Track consecutive sync failures and auto-exclude broken records
+- **`sync_dependencies`** — Buffer syncs until dependencies have a `crm_id`
+
+**Bug fixes:**
+
+- `StaleRecords::Finder` now handles `has_one :through` dependencies where the through association is a `belongs_to`
+- `StaleRecords::Finder` now handles STI subclasses without `PG::UndefinedColumn` errors
+
+---
+
+## 2. Database migrations (required)
+
+### 2.1. Add `error_count` column
+
+```bash
+rails g etlify:add_error_count
+rails db:migrate
+```
+
+This adds an `error_count` integer column (default: `0`) to `crm_synchronisations`.
+
+### 2.2. Create `etlify_pending_syncs` table
+
+Only required if you plan to use `sync_dependencies`:
+
+```bash
+rails g etlify:migration create_etlify_pending_syncs
+rails db:migrate
+```
+
+---
+
+## 3. Configuration (optional)
+
+### 3.1. `max_sync_errors`
+
+Records exceeding this limit are automatically excluded from `StaleRecords::Finder`.
+Default: `3`.
+
+```ruby
+# Global
+Etlify.configure do |config|
+  config.max_sync_errors = 5
+end
+
+# Or per-CRM
+Etlify::CRM.register(
+  :hubspot,
+  adapter: Etlify::Adapters::HubspotV3Adapter.new(
+    access_token: ENV["HUBSPOT_PRIVATE_APP_TOKEN"]
+  ),
+  options: { max_sync_errors: 5 }
+)
+```
+
+To manually re-enable sync on a record after fixing the root cause:
+
+```ruby
+CrmSynchronisation.find(id).reset_error_count!
+```
+
+---
+
+## 4. New DSL options (optional)
+
+### 4.1. `stale_scope`
+
+Restricts which records `StaleRecords::Finder` considers. Applied at SQL level
+before any record is processed. Prevents unnecessary `CrmSynchronisation` rows
+for records that `sync_if` would skip.
+
+```ruby
+class User < ApplicationRecord
+  include Etlify::Model
+
+  hubspot_etlified_with(
+    serializer: Etlify::Serializers::UserSerializer,
+    crm_object_type: "contacts",
+    id_property: "email",
+    stale_scope: ->(rel) { rel.where(active: true) }
+  )
+end
+```
+
+Models without `stale_scope` are not affected — the Finder behaves as before.
+
+### 4.2. `sync_dependencies`
+
+Buffers sync when a dependency has no `crm_id` yet. Automatically retries once
+the dependency is synced. Supports both etlified models (via `CrmSynchronisation`)
+and legacy models with a direct `#{crm_name}_id` column.
+
+```ruby
+class Employee < ApplicationRecord
+  include Etlify::Model
+
+  hubspot_etlified_with(
+    serializer: Etlify::Serializers::EmployeeSerializer,
+    crm_object_type: "contacts",
+    id_property: "email",
+    dependencies: [:company],
+    sync_dependencies: [:company]
+  )
+end
+```
+
+> **Note:** `dependencies` controls freshness checks (re-sync when dependency
+> changes). `sync_dependencies` controls ordering (block until dependency has a
+> `crm_id`). They can overlap but serve different purposes.
+
+---
+
+## 5. QA & testing checklist
+
+- [ ] Migration adds `error_count` to `crm_synchronisations`
+- [ ] Migration creates `etlify_pending_syncs` table (if using `sync_dependencies`)
+- [ ] Records with `error_count >= max_sync_errors` are excluded from `StaleRecords::Finder`
+- [ ] `CrmSynchronisation#reset_error_count!` re-enables sync
+- [ ] `stale_scope` correctly restricts the Finder query
+- [ ] `sync_dependencies` buffers and flushes correctly
+- [ ] STI models sync without `PG::UndefinedColumn` errors
+- [ ] `has_one :through` (via `belongs_to`) dependencies are detected as stale
+
+---
+
+## 6. Backward compatibility
+
+All features are backward compatible. Existing code continues to work without
+changes. The `error_count` migration is strongly recommended to avoid retrying
+permanently broken records.
+
+---
+
+# UPGRADING FROM 0.9.2 -> 0.9.3
+
+- Nothing to do (bugfix: custom `job_class` support in `BatchSync` via CRM options)
+
 # UPGRADING FROM 0.9.1 -> 0.9.2
 
 - Nothing to do (bugfix)


### PR DESCRIPTION
## Summary
- Add upgrade instructions for 0.9.2 → 0.9.3 (bugfix only, nothing to do)
- Add detailed upgrade guide for 0.9.3 → 0.9.4 covering:
  - Required migrations (`error_count`, `etlify_pending_syncs`)
  - New config option `max_sync_errors`
  - New DSL options `stale_scope` and `sync_dependencies`
  - QA checklist and backward compatibility notes

## Test plan
- [ ] Review upgrade instructions for accuracy against CHANGELOG.md
- [ ] Verify migration commands work on a fresh app