### PR TITLE
feat: add batch_upsert! and batch_delete! to HubspotV3Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 - Feat: Add `AirtableV0Adapter` for Airtable API v0 integration. Supports `upsert!` and `delete!` (standard Etlify interface) plus batch operations: `batch_upsert!` (via Airtable's native `performUpsert`, up to 10 records per request) and `batch_delete!`. Uses `Net::HTTP` (zero external dependency), injectable `http_client:` for testing, and structured error handling via the Etlify error hierarchy.
+- Feat: Add `batch_upsert!` and `batch_delete!` to `HubspotV3Adapter`. Leverages HubSpot's native batch endpoints (`POST /batch/upsert` and `POST /batch/archive`, up to 100 inputs per request). Follows the same interface pattern as `AirtableV0Adapter` batch operations.
 
 # V0.9.4
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,34 @@ class Subscription < ApplicationRecord
 end
 ```
 
+### Batch operations
+
+The HubSpot adapter provides two additional methods for bulk operations, using HubSpot's native batch endpoints (up to 100 inputs per request, auto-sliced):
+
+```ruby
+adapter = Etlify::CRM.registry[:hubspot].adapter
+
+# Batch upsert via HubSpot's native /batch/upsert
+# Returns an Array of hs_object_id strings
+adapter.batch_upsert!(
+  object_type: "contacts",
+  records: [
+    {email: "a@example.com", firstname: "Alice"},
+    {email: "b@example.com", firstname: "Bob"},
+  ],
+  id_property: "email"
+)
+
+# Batch delete (archive) via /batch/archive
+# Returns true
+adapter.batch_delete!(
+  object_type: "contacts",
+  crm_ids: ["101", "102", "103"]
+)
+```
+
+> **Rate limiting:** HubSpot enforces rate limits per private app. Batch operations process up to 100 records per request (vs 1 for single-record calls), significantly reducing the number of API calls.
+
 ---
 
 ## Airtable adapter (API v0)
@@ -633,7 +661,7 @@ expect(fake_adapter).to have_received(:upsert!).with(
 ## Adapters included
 
 - `Etlify::Adapters::NullAdapter` (default; no-op)
-- `Etlify::Adapters::HubspotV3Adapter` (API v3)
+- `Etlify::Adapters::HubspotV3Adapter` (API v3, with batch support)
 - `Etlify::Adapters::AirtableV0Adapter` (API v0, with batch support)
 
 ---

--- a/lib/etlify/adapters/hubspot_v3_adapter.rb
+++ b/lib/etlify/adapters/hubspot_v3_adapter.rb
@@ -19,6 +19,7 @@ module Etlify
     #   adapter.delete!(object_type: "contacts", crm_id: "123") # => true, or false if 404
     class HubspotV3Adapter
       API_BASE = "https://api.hubapi.com"
+      BATCH_MAX_SIZE = 100
 
       # @param access_token [String] HubSpot private app token
       # @param http_client [#request] Optional HTTP client for tests. Signature: request(method, url, headers:, body:)
@@ -84,6 +85,59 @@ module Etlify
         return false if resp[:status] == 404
 
         raise_for_error!(resp, path: path)
+      end
+
+      # Batch upsert via HubSpot's native /batch/upsert endpoint.
+      # @param object_type [String] CRM object type
+      # @param records [Array<Hash>] Properties hashes (must include the id_property key)
+      # @param id_property [String] Unique property for matching (e.g., "email")
+      # @return [Array<String>] hs_object_id strings for each upserted record
+      def batch_upsert!(object_type:, records:, id_property:)
+        raise ArgumentError, "object_type must be a String" unless object_type.is_a?(String) && !object_type.empty?
+        raise ArgumentError, "id_property must be provided" if id_property.nil? || id_property.to_s.empty?
+        raise ArgumentError, "records must be a non-empty Array" unless records.is_a?(Array) && !records.empty?
+
+        path = "/crm/v3/objects/#{object_type}/batch/upsert"
+
+        records.each_slice(BATCH_MAX_SIZE).flat_map do |slice|
+          body = {
+            inputs: slice.map do |record|
+              props = stringify_keys(record)
+              id_value = props.delete(id_property.to_s)
+              {
+                id: id_value.to_s,
+                idProperty: id_property.to_s,
+                properties: props,
+              }
+            end,
+          }
+
+          resp = request(:post, path, body: body)
+          raise_for_error!(resp, path: path)
+          extract_batch_ids(resp)
+        end
+      end
+
+      # Batch delete (archive) via HubSpot's native /batch/archive endpoint.
+      # @param object_type [String] CRM object type
+      # @param crm_ids [Array<String>] hs_object_id values to archive
+      # @return [Boolean] true when all batches succeed
+      def batch_delete!(object_type:, crm_ids:)
+        raise ArgumentError, "object_type must be a String" unless object_type.is_a?(String) && !object_type.empty?
+        raise ArgumentError, "crm_ids must be a non-empty Array" unless crm_ids.is_a?(Array) && !crm_ids.empty?
+
+        path = "/crm/v3/objects/#{object_type}/batch/archive"
+
+        crm_ids.each_slice(BATCH_MAX_SIZE) do |slice|
+          body = {
+            inputs: slice.map { |id| {id: id.to_s} },
+          }
+
+          resp = request(:post, path, body: body)
+          raise_for_error!(resp, path: path)
+        end
+
+        true
       end
 
       private
@@ -245,6 +299,13 @@ module Etlify
         end
 
         raise_for_error!(resp, path: path)
+      end
+
+      def extract_batch_ids(resp)
+        results = resp[:json].is_a?(Hash) ? resp[:json]["results"] : nil
+        return [] unless results.is_a?(Array)
+
+        results.map { |r| r["id"].to_s }
       end
 
       def stringify_keys(hash)

--- a/spec/adapters/hubspot_adapter_spec.rb
+++ b/spec/adapters/hubspot_adapter_spec.rb
@@ -937,4 +937,336 @@ RSpec.describe Etlify::Adapters::HubspotV3Adapter do
       end.to raise_error(Etlify::TransportError, /network oops/)
     end
   end
+
+  describe "#batch_upsert!" do
+    let(:upsert_url) { "https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert" }
+
+    it "POSTs to batch/upsert and returns IDs",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :post,
+        upsert_url,
+        headers: hash_including("Authorization" => "Bearer #{token}"),
+        body: satisfy { |body|
+          json = JSON.parse(body)
+          inputs = json["inputs"]
+          inputs.size == 2 &&
+            inputs[0]["id"] == "john@example.com" &&
+            inputs[0]["idProperty"] == "email" &&
+            inputs[0]["properties"] == {"firstname" => "John"} &&
+            inputs[1]["id"] == "jane@example.com" &&
+            inputs[1]["idProperty"] == "email" &&
+            inputs[1]["properties"] == {"firstname" => "Jane"}
+        }
+      ).and_return(
+        {
+          status: 200,
+          body: {
+            status: "COMPLETE",
+            results: [
+              {"id" => "101", "properties" => {}},
+              {"id" => "102", "properties" => {}},
+            ],
+          }.to_json,
+        }
+      )
+
+      ids = adapter.batch_upsert!(
+        object_type: "contacts",
+        records: [
+          {email: "john@example.com", firstname: "John"},
+          {email: "jane@example.com", firstname: "Jane"},
+        ],
+        id_property: "email"
+      )
+      expect(ids).to eq(["101", "102"])
+    end
+
+    it "slices records into batches of BATCH_MAX_SIZE",
+       :aggregate_failures do
+      records = (1..150).map do |i|
+        {email: "user#{i}@example.com", firstname: "User#{i}"}
+      end
+
+      expect(http).to receive(:request).with(
+        :post, upsert_url, anything
+      ).twice.and_return(
+        {
+          status: 200,
+          body: {
+            status: "COMPLETE",
+            results: [{"id" => "1", "properties" => {}}],
+          }.to_json,
+        }
+      )
+
+      ids = adapter.batch_upsert!(
+        object_type: "contacts",
+        records: records,
+        id_property: "email"
+      )
+      expect(ids).to eq(["1", "1"])
+    end
+
+    it "stringifies symbol keys in records",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :post,
+        upsert_url,
+        headers: anything,
+        body: satisfy { |body|
+          json = JSON.parse(body)
+          props = json["inputs"].first["properties"]
+          props.keys.all? { |k| k.is_a?(String) }
+        }
+      ).and_return(
+        {
+          status: 200,
+          body: {
+            results: [{"id" => "1"}],
+          }.to_json,
+        }
+      )
+
+      adapter.batch_upsert!(
+        object_type: "contacts",
+        records: [{email: "a@b.com", firstname: "A"}],
+        id_property: "email"
+      )
+    end
+
+    it "works with custom object types" do
+      custom_url = "https://api.hubapi.com/crm/v3/objects/p12345_myobject/batch/upsert"
+
+      expect(http).to receive(:request).with(
+        :post, custom_url, anything
+      ).and_return(
+        {
+          status: 200,
+          body: {results: [{"id" => "42"}]}.to_json,
+        }
+      )
+
+      ids = adapter.batch_upsert!(
+        object_type: "p12345_myobject",
+        records: [{"ref" => "ABC", "name" => "Test"}],
+        id_property: "ref"
+      )
+      expect(ids).to eq(["42"])
+    end
+
+    it "raises ArgumentError on invalid arguments",
+       :aggregate_failures do
+      expect do
+        adapter.batch_upsert!(
+          object_type: "",
+          records: [{}],
+          id_property: "email"
+        )
+      end.to raise_error(ArgumentError, /object_type/)
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [{}],
+          id_property: nil
+        )
+      end.to raise_error(ArgumentError, /id_property/)
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: "not array",
+          id_property: "email"
+        )
+      end.to raise_error(ArgumentError, /records/)
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [],
+          id_property: "email"
+        )
+      end.to raise_error(ArgumentError, /records/)
+    end
+
+    it "raises Unauthorized on 401" do
+      expect(http).to receive(:request).and_return(
+        {
+          status: 401,
+          body: {
+            message: "Invalid token",
+            category: "INVALID_AUTHENTICATION",
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [{email: "a@b.com"}],
+          id_property: "email"
+        )
+      end.to raise_error(Etlify::Unauthorized, /Invalid token/)
+    end
+
+    it "raises RateLimited on 429" do
+      expect(http).to receive(:request).and_return(
+        {
+          status: 429,
+          body: {
+            message: "Too many requests",
+            category: "RATE_LIMITS",
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [{email: "a@b.com"}],
+          id_property: "email"
+        )
+      end.to raise_error(Etlify::RateLimited, /Too many requests/)
+    end
+
+    it "raises ApiError on 500" do
+      expect(http).to receive(:request).and_return(
+        {status: 500, body: {message: "Server down"}.to_json}
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [{email: "a@b.com"}],
+          id_property: "email"
+        )
+      end.to raise_error(Etlify::ApiError, /Server down/)
+    end
+
+    it "wraps transport errors into TransportError" do
+      expect(http).to receive(:request).and_raise(
+        StandardError.new("connection reset")
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: "contacts",
+          records: [{email: "a@b.com"}],
+          id_property: "email"
+        )
+      end.to raise_error(Etlify::TransportError, /connection reset/)
+    end
+  end
+
+  describe "#batch_delete!" do
+    let(:archive_url) { "https://api.hubapi.com/crm/v3/objects/contacts/batch/archive" }
+
+    it "POSTs to batch/archive and returns true",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :post,
+        archive_url,
+        headers: hash_including("Authorization" => "Bearer #{token}"),
+        body: satisfy { |body|
+          json = JSON.parse(body)
+          json["inputs"] == [
+            {"id" => "101"},
+            {"id" => "102"},
+            {"id" => "103"},
+          ]
+        }
+      ).and_return({status: 204, body: ""})
+
+      result = adapter.batch_delete!(
+        object_type: "contacts",
+        crm_ids: ["101", "102", "103"]
+      )
+      expect(result).to be true
+    end
+
+    it "slices crm_ids into batches of BATCH_MAX_SIZE",
+       :aggregate_failures do
+      ids = (1..150).map(&:to_s)
+
+      expect(http).to receive(:request).with(
+        :post, archive_url, anything
+      ).twice.and_return({status: 204, body: ""})
+
+      result = adapter.batch_delete!(
+        object_type: "contacts",
+        crm_ids: ids
+      )
+      expect(result).to be true
+    end
+
+    it "raises ArgumentError on invalid arguments",
+       :aggregate_failures do
+      expect do
+        adapter.batch_delete!(
+          object_type: "",
+          crm_ids: ["1"]
+        )
+      end.to raise_error(ArgumentError, /object_type/)
+
+      expect do
+        adapter.batch_delete!(
+          object_type: "contacts",
+          crm_ids: "not array"
+        )
+      end.to raise_error(ArgumentError, /crm_ids/)
+
+      expect do
+        adapter.batch_delete!(
+          object_type: "contacts",
+          crm_ids: []
+        )
+      end.to raise_error(ArgumentError, /crm_ids/)
+    end
+
+    it "raises Unauthorized on 401" do
+      expect(http).to receive(:request).and_return(
+        {
+          status: 401,
+          body: {
+            message: "Invalid token",
+            category: "INVALID_AUTHENTICATION",
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: "contacts",
+          crm_ids: ["1"]
+        )
+      end.to raise_error(Etlify::Unauthorized, /Invalid token/)
+    end
+
+    it "raises ApiError on 500" do
+      expect(http).to receive(:request).and_return(
+        {status: 500, body: {message: "Server down"}.to_json}
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: "contacts",
+          crm_ids: ["1"]
+        )
+      end.to raise_error(Etlify::ApiError, /Server down/)
+    end
+
+    it "wraps transport errors into TransportError" do
+      expect(http).to receive(:request).and_raise(
+        StandardError.new("dns failure")
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: "contacts",
+          crm_ids: ["1"]
+        )
+      end.to raise_error(Etlify::TransportError, /dns failure/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `batch_upsert!(object_type:, records:, id_property:)` using HubSpot's native `POST /batch/upsert` endpoint
- Add `batch_delete!(object_type:, crm_ids:)` using HubSpot's native `POST /batch/archive` endpoint
- Both methods slice inputs into chunks of 100 (HubSpot API limit)
- Follows the same patterns as `AirtableV0Adapter` batch operations

## Test plan
- [x] 54 specs pass (14 new covering happy path, slicing, validation, API errors, transport errors)
- [ ] Manual test with a HubSpot sandbox (batch upsert contacts, batch archive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)