### PR TITLE
Add AirtableV0Adapter with batch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Feat: Add `Etlify::BatchSynchronizer` — batch-aware synchronizer that applies per-record pre-checks (guard, digest, dependencies) then calls `adapter.batch_upsert!` for all ready records. Used by `BatchSyncJob` when the adapter supports it, with fallback to sequential `Synchronizer.call`.
 - Feat: Adapters now support an optional `rate_limiter=` accessor for per-HTTP-request throttling.
 - Feat: Add `batch_upsert!` and `batch_delete!` to `NullAdapter` for test support.
+- Feat: Add `AirtableV0Adapter` for Airtable API v0 integration. Supports `upsert!` and `delete!` (standard Etlify interface) plus batch operations: `batch_upsert!` (via Airtable's native `performUpsert`, up to 10 records per request) and `batch_delete!`. Uses `Net::HTTP` (zero external dependency), injectable `http_client:` for testing, and structured error handling via the Etlify error hierarchy. Supports rate limiting via `rate_limiter=` accessor.
 
 # V0.9.4
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Etlify sits beside your app; it does **not** try to own your domain or backgroun
 | ----------- | ------------------------------------------------------------- | --------------------------------------------------- |
 | DSL         | `include Etlify::Model` + `etlified_with(...)` on your models | Opt-in sync with a single line; clear, local intent |
 | Serialisers | A base class to turn a model into a CRM payload               | Keeps mapping logic where it belongs; easy to test  |
-| Adapters    | HubSpot adapter included; plug your own                       | Swap CRMs without touching model code               |
+| Adapters    | HubSpot & Airtable adapters included; plug your own           | Swap CRMs without touching model code               |
 | Idempotence | Stable digest of the last synced payload                      | Avoids redundant API calls; safe to retry           |
 | Jobs        | `crm_sync!` enqueues an ActiveJob; batch sync via `BatchSyncJob` | Fits your queue; built-in rate limiting              |
 | Delete      | `crm_delete!` to remove a record from the CRM                 | Keeps both sides consistent                         |
@@ -354,7 +354,7 @@ The method returns a stats Hash:
 
 ### Rate limiting
 
-CRM APIs enforce rate limits (e.g. HubSpot: ~100 requests/10s). Etlify provides built-in rate limiting at the **adapter level** (per HTTP request), so multi-request operations like search + upsert are correctly throttled.
+CRM APIs enforce rate limits (e.g. HubSpot: ~100 requests/10s, Airtable: 5 requests/s). Etlify provides built-in rate limiting at the **adapter level** (per HTTP request), so multi-request operations like search + upsert are correctly throttled.
 
 #### Configuration
 
@@ -521,6 +521,80 @@ adapter.batch_delete!(
 
 ---
 
+## Airtable adapter (API v0)
+
+Etlify ships with `Etlify::Adapters::AirtableV0Adapter`. It uses `Net::HTTP` (no external dependency) and supports both single-record and batch operations.
+
+### Configuration
+
+```ruby
+Etlify.configure do |config|
+  Etlify::CRM.register(
+    :airtable,
+    adapter: Etlify::Adapters::AirtableV0Adapter.new(
+      access_token: ENV["AIRTABLE_TOKEN"],
+      base_id: ENV["AIRTABLE_BASE_ID"]
+    ),
+    options: {
+      rate_limit: { max_requests: 5, period: 1 },
+    }
+  )
+end
+```
+
+### Behaviour
+
+- `object_type`: the Airtable table ID or name (e.g. `"tblContacts"`, `"Contacts"`).
+- `id_property`: field name used to search for existing records via `filterByFormula`. If a match is found, the record is updated; otherwise a new record is created.
+- `crm_id`: if provided (e.g. `"recXXXXXXXX"`), the adapter skips the search and updates the record directly.
+
+### Example: Contact upsert
+
+```ruby
+class User < ApplicationRecord
+  include Etlify::Model
+
+  airtable_etlified_with(
+    serializer: UserSerializer,
+    crm_object_type: "tblContacts",
+    id_property: :Email,
+    sync_if: ->(user) { user.email.present? }
+  )
+end
+
+# Later
+user.airtable_crm_sync!
+```
+
+### Batch operations
+
+The Airtable adapter provides two additional methods for bulk operations, using Airtable's native batch endpoints (up to 10 records per request, auto-sliced):
+
+```ruby
+adapter = Etlify::CRM.registry[:airtable].adapter
+
+# Batch upsert via Airtable's native performUpsert
+# Returns a Hash { id_property_value => record_id }
+adapter.batch_upsert!(
+  object_type: "tblContacts",
+  records: [
+    {Email: "a@example.com", Name: "Alice"},
+    {Email: "b@example.com", Name: "Bob"},
+  ],
+  id_property: "Email"
+)
+
+# Batch delete
+adapter.batch_delete!(
+  object_type: "tblContacts",
+  crm_ids: ["recAAA", "recBBB", "recCCC"]
+)
+```
+
+> **Rate limiting:** Airtable enforces 5 requests/second/base. Batch operations process up to 10 records per request (vs 1 for single-record calls), increasing effective throughput to 50 records/second.
+
+---
+
 ## Writing your own adapter
 
 Implement the following interface:
@@ -628,6 +702,7 @@ expect(fake_adapter).to have_received(:upsert!).with(
 
 - `Etlify::Adapters::NullAdapter` (default; no-op)
 - `Etlify::Adapters::HubspotV3Adapter` (API v3, with batch support)
+- `Etlify::Adapters::AirtableV0Adapter` (API v0, with batch support)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Etlify::CRM.register(
     access_token: ENV[“HUBSPOT_PRIVATE_APP_TOKEN”]
   ),
   options: {
-    rate_limit: { max_requests: 100, period: 10 },
+    rate_limit: { max_requests: 100, period: 10.seconds },
     max_sync_errors: 5,
   }
 )
@@ -536,7 +536,7 @@ Etlify.configure do |config|
       base_id: ENV["AIRTABLE_BASE_ID"]
     ),
     options: {
-      rate_limit: { max_requests: 5, period: 1 }, # seconds
+      rate_limit: { max_requests: 5, period: 1.second },
     }
   )
 end

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Etlify.configure do |config|
       base_id: ENV["AIRTABLE_BASE_ID"]
     ),
     options: {
-      rate_limit: { max_requests: 5, period: 1 },
+      rate_limit: { max_requests: 5, period: 1 }, # seconds
     }
   )
 end

--- a/lib/etlify/adapters.rb
+++ b/lib/etlify/adapters.rb
@@ -1,2 +1,3 @@
 require_relative "adapters/null_adapter"
 require_relative "adapters/hubspot_v3_adapter"
+require_relative "adapters/airtable_v0_adapter"

--- a/lib/etlify/adapters/airtable_v0/client.rb
+++ b/lib/etlify/adapters/airtable_v0/client.rb
@@ -1,0 +1,123 @@
+require "json"
+require "uri"
+
+module Etlify
+  module Adapters
+    module AirtableV0
+      # Low-level HTTP client for the Airtable API v0.
+      # Handles request building, authentication, JSON
+      # parsing, and error mapping.
+      class Client
+        API_BASE = "https://api.airtable.com/v0"
+
+        attr_accessor :rate_limiter
+
+        def initialize(access_token:, base_id:, http:)
+          @access_token = access_token
+          @base_id      = base_id
+          @http         = http
+        end
+
+        def get(path, query: {})
+          request(:get, path, query: query)
+        end
+
+        def post(path, body:)
+          request(:post, path, body: body)
+        end
+
+        def patch(path, body:)
+          request(:patch, path, body: body)
+        end
+
+        def delete(path, query: {})
+          request(:delete, path, query: query)
+        end
+
+        def base_path(object_type)
+          "/#{@base_id}/#{object_type}"
+        end
+
+        def raise_for_error!(response, path:)
+          status = response[:status].to_i
+          return if status.between?(200, 299)
+
+          body = response[:json].is_a?(Hash) ? response[:json] : {}
+          error_detail = body["error"]
+
+          message = if error_detail.is_a?(Hash)
+            error_detail["message"] || "Airtable API request failed"
+          else
+            body["message"] || "Airtable API request failed"
+          end
+
+          error_type = error_detail["type"] if error_detail.is_a?(Hash)
+          full_message = "#{message} (status=#{status}, path=#{path}"
+          full_message << ", type=#{error_type}" if error_type
+          full_message << ")"
+
+          error_class =
+            case status
+            when 401, 403 then Etlify::Unauthorized
+            when 404      then Etlify::NotFound
+            when 409, 422 then Etlify::ValidationFailed
+            when 429      then Etlify::RateLimited
+            else Etlify::ApiError
+            end
+
+          raise error_class.new(
+            full_message,
+            status: status,
+            code: error_type,
+            category: error_type,
+            correlation_id: nil,
+            details: error_detail,
+            raw: response[:body]
+          )
+        end
+
+        private
+
+        def request(method, path, body: nil, query: {})
+          @rate_limiter&.throttle!
+
+          url = API_BASE + path
+          unless query.empty?
+            url += "?#{URI.encode_www_form(query)}"
+          end
+
+          headers = {
+            "Authorization" => "Bearer #{@access_token}",
+            "Content-Type" => "application/json",
+            "Accept" => "application/json",
+          }
+
+          raw_body = body && JSON.dump(body)
+
+          begin
+            response = @http.request(
+              method, url, headers: headers, body: raw_body
+            )
+          rescue => exception
+            raise Etlify::TransportError.new(
+              "HTTP transport error: #{exception.class}: #{exception.message}",
+              status: 0,
+              raw: nil
+            )
+          end
+
+          response[:json] = parse_json_safe(response[:body])
+          response
+        end
+
+        def parse_json_safe(raw_body)
+          return nil if raw_body.nil? || raw_body.empty?
+
+          JSON.parse(raw_body)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/etlify/adapters/airtable_v0/client.rb
+++ b/lib/etlify/adapters/airtable_v0/client.rb
@@ -35,7 +35,11 @@ module Etlify
         end
 
         def base_path(object_type)
-          "/#{@base_id}/#{object_type}"
+          "/#{@base_id}/#{encode_path_segment(object_type)}"
+        end
+
+        def record_path(object_type, record_id)
+          "#{base_path(object_type)}/#{encode_path_segment(record_id)}"
         end
 
         def raise_for_error!(response, path:)
@@ -108,6 +112,11 @@ module Etlify
 
           response[:json] = parse_json_safe(response[:body])
           response
+        end
+
+        def encode_path_segment(segment)
+          URI.encode_www_form_component(segment.to_s)
+             .gsub("+", "%20")
         end
 
         def parse_json_safe(raw_body)

--- a/lib/etlify/adapters/airtable_v0/formula.rb
+++ b/lib/etlify/adapters/airtable_v0/formula.rb
@@ -1,0 +1,47 @@
+module Etlify
+  module Adapters
+    module AirtableV0
+      # Helpers for building Airtable filterByFormula
+      # expressions.
+      module Formula
+        SAFE_FIELD_NAME = /\A[\w\s\-]+\z/
+
+        module_function
+
+        # Build a filterByFormula equality expression.
+        # @param field_name [String]
+        # @param value [String, Numeric]
+        # @return [String] e.g. '{Email} = "john@example.com"'
+        def eq(field_name, value)
+          validate_field_name!(field_name)
+          "{#{field_name}} = #{escape(value)}"
+        end
+
+        # Escape a value for use inside a formula string.
+        # Numerics are left unquoted; strings are
+        # double-quoted with internal quotes escaped.
+        # Non-scalar types raise ArgumentError.
+        def escape(value)
+          if value.is_a?(Numeric)
+            value.to_s
+          elsif value.is_a?(String) || value.is_a?(Symbol)
+            escaped_value = value.to_s
+                                 .gsub("\\", "\\\\\\\\")
+                                 .gsub('"', '\\"')
+            "\"#{escaped_value}\""
+          else
+            raise ArgumentError,
+                  "Formula value must be a String, Symbol, or Numeric (got #{value.class})"
+          end
+        end
+
+        def validate_field_name!(field_name)
+          return if field_name.is_a?(String) && field_name.match?(SAFE_FIELD_NAME)
+
+          raise ArgumentError,
+                "Invalid Airtable field name: #{field_name.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/lib/etlify/adapters/airtable_v0_adapter.rb
+++ b/lib/etlify/adapters/airtable_v0_adapter.rb
@@ -218,8 +218,7 @@ module Etlify
       def validate_string!(name, value)
         return if value.is_a?(String) && !value.empty?
 
-        raise ArgumentError,
-              "#{name} must be a non-empty String"
+        raise ArgumentError, "#{name} must be a non-empty String"
       end
 
       def validate_present!(name, value)
@@ -231,8 +230,7 @@ module Etlify
       def validate_path_segment!(name, value)
         return if value.is_a?(String) && value.match?(SAFE_PATH_SEGMENT)
 
-        raise ArgumentError,
-              "#{name} must be a safe path segment (got #{value.inspect})"
+        raise ArgumentError, "#{name} must be a safe path segment (got #{value.inspect})"
       end
     end
   end

--- a/lib/etlify/adapters/airtable_v0_adapter.rb
+++ b/lib/etlify/adapters/airtable_v0_adapter.rb
@@ -1,0 +1,239 @@
+require_relative "default_http"
+require_relative "airtable_v0/client"
+require_relative "airtable_v0/formula"
+
+module Etlify
+  module Adapters
+    # Airtable Adapter (API v0) with per-call table type.
+    #
+    # Usage:
+    #   adapter = Etlify::Adapters::AirtableV0Adapter.new(
+    #     access_token: ENV["AIRTABLE_TOKEN"],
+    #     base_id: "appXXXXXXXXXXXXXX",
+    #   )
+    #   adapter.upsert!(object_type: "tblXXX", payload: {Name: "John"}, id_property: "Email")
+    #   adapter.delete!(object_type: "tblXXX", crm_id: "recXXX")
+    #   adapter.batch_upsert!(object_type: "tblXXX", records: [...], id_property: "Email")
+    #   adapter.batch_delete!(object_type: "tblXXX", crm_ids: ["recAAA", "recBBB"])
+    class AirtableV0Adapter
+      BATCH_MAX_SIZE = 10
+      SAFE_PATH_SEGMENT = /\A[\w\-]+\z/
+
+      def rate_limiter
+        @client.rate_limiter
+      end
+
+      def rate_limiter=(limiter)
+        @client.rate_limiter = limiter
+      end
+
+      def initialize(access_token:, base_id:, http_client: nil)
+        validate_string!(:access_token, access_token)
+        validate_string!(:base_id, base_id)
+
+        @client = AirtableV0::Client.new(
+          access_token: access_token,
+          base_id: base_id,
+          http: http_client || DefaultHttp.new
+        )
+      end
+
+      # --- Standard Etlify interface ---
+
+      # Note: unlike HubSpot, id_property is kept in the
+      # payload because Airtable requires the field in
+      # `fields` for both create and update operations.
+      # For bulk operations, prefer batch_upsert! which uses
+      # Airtable's native performUpsert (up to 10 rec/req).
+      def upsert!(object_type:, payload:, id_property: nil, crm_id: nil)
+        validate_path_segment!(:object_type, object_type)
+        raise ArgumentError, "payload must be a Hash" unless payload.is_a?(Hash)
+
+        properties = payload.dup
+        object_id  = resolve_object_id(
+          object_type, properties, id_property, crm_id
+        )
+
+        if object_id
+          update_record(object_type, object_id, properties)
+          object_id.to_s
+        else
+          create_record(object_type, properties)
+        end
+      end
+
+      def delete!(object_type:, crm_id:)
+        validate_path_segment!(:object_type, object_type)
+        validate_path_segment!(:crm_id, crm_id)
+
+        path = "#{@client.base_path(object_type)}/#{crm_id}"
+        response = @client.delete(path)
+
+        return true if response[:status].between?(200, 299)
+        return false if response[:status] == 404
+
+        @client.raise_for_error!(response, path: path)
+      end
+
+      # --- Batch operations (Airtable-specific) ---
+
+      # Note: if a later slice fails, records from earlier
+      # slices are already committed. Callers should handle
+      # partial success when processing large batches.
+      # @return [Hash{String => String}] mapping of id_property value to Airtable record ID
+      def batch_upsert!(object_type:, records:, id_property:)
+        validate_path_segment!(:object_type, object_type)
+        validate_present!(:id_property, id_property)
+        unless records.is_a?(Array) && !records.empty?
+          raise ArgumentError,
+                "records must be a non-empty Array"
+        end
+
+        path = @client.base_path(object_type)
+        prop_key = id_property.to_s
+
+        records.each_slice(BATCH_MAX_SIZE).each_with_object({}) do |slice, mapping|
+          body = {
+            performUpsert: {
+              fieldsToMergeOn: [prop_key],
+            },
+            records: slice.map { |fields| {fields: stringify_keys(fields)} },
+          }
+
+          response = @client.patch(path, body: body)
+          @client.raise_for_error!(response, path: path)
+          extract_batch_mapping(response, prop_key).each { |k, v| mapping[k] = v }
+        end
+      end
+
+      # Note: if a later slice fails, records from earlier
+      # slices are already deleted. Callers should handle
+      # partial success when processing large batches.
+      def batch_delete!(object_type:, crm_ids:)
+        validate_path_segment!(:object_type, object_type)
+        unless crm_ids.is_a?(Array) && !crm_ids.empty?
+          raise ArgumentError,
+                "crm_ids must be a non-empty Array"
+        end
+
+        path = @client.base_path(object_type)
+
+        crm_ids.each_slice(BATCH_MAX_SIZE).flat_map do |slice|
+          query = slice.map { |id| ["records[]", id.to_s] }
+          response = @client.delete(path, query: query)
+          @client.raise_for_error!(response, path: path)
+          extract_records(response)
+        end
+      end
+
+      private
+
+      # --- Record operations ---
+
+      def find_record_by_field(object_type, field_name, value)
+        formula = AirtableV0::Formula.eq(field_name, value)
+        path = @client.base_path(object_type)
+
+        response = @client.get(path, query: {
+          "filterByFormula" => formula,
+          "maxRecords" => 1,
+        })
+
+        return first_record_id(response) if response[:status] == 200
+        return nil if response[:status] == 404
+
+        @client.raise_for_error!(response, path: path)
+      end
+
+      def create_record(object_type, payload)
+        path = @client.base_path(object_type)
+        response = @client.post(path, body: {fields: stringify_keys(payload)})
+        @client.raise_for_error!(response, path: path)
+
+        record_id = response[:json].is_a?(Hash) && response[:json]["id"]
+
+        unless record_id
+          raise Etlify::ApiError.new(
+            "Airtable create succeeded but returned no record id (path=#{path})",
+            status: response[:status],
+            raw: response[:body]
+          )
+        end
+
+        record_id.to_s
+      end
+
+      def update_record(object_type, record_id, payload)
+        path = "#{@client.base_path(object_type)}/#{record_id}"
+        response = @client.patch(path, body: {fields: stringify_keys(payload)})
+        @client.raise_for_error!(response, path: path)
+        true
+      end
+
+      # --- Helpers ---
+
+      def resolve_object_id(object_type, properties, id_property, crm_id)
+        unless crm_id.to_s.strip.empty?
+          return crm_id.to_s.strip
+        end
+
+        return nil unless id_property
+
+        key_str = id_property.to_s
+        unique_value = properties[key_str] || properties[key_str.to_sym]
+
+        return nil unless unique_value
+
+        find_record_by_field(object_type, key_str, unique_value)
+      end
+
+      def first_record_id(response)
+        return nil unless response[:json].is_a?(Hash)
+
+        records = response[:json]["records"]
+        return nil unless records.is_a?(Array) && records.any?
+
+        records.first["id"]
+      end
+
+      def extract_records(response)
+        returned = response[:json].is_a?(Hash) ? response[:json]["records"] : nil
+        returned.is_a?(Array) ? returned : []
+      end
+
+      def extract_batch_mapping(response, id_property)
+        records = extract_records(response)
+        records.each_with_object({}) do |r, h|
+          record_id = r["id"].to_s
+          fields = r["fields"] || {}
+          id_value = (fields[id_property] || "").to_s
+          h[id_value] = record_id unless id_value.empty?
+        end
+      end
+
+      def stringify_keys(hash)
+        hash.transform_keys(&:to_s)
+      end
+
+      def validate_string!(name, value)
+        return if value.is_a?(String) && !value.empty?
+
+        raise ArgumentError,
+              "#{name} must be a non-empty String"
+      end
+
+      def validate_present!(name, value)
+        return unless value.nil? || value.to_s.empty?
+
+        raise ArgumentError, "#{name} must be provided"
+      end
+
+      def validate_path_segment!(name, value)
+        return if value.is_a?(String) && value.match?(SAFE_PATH_SEGMENT)
+
+        raise ArgumentError,
+              "#{name} must be a safe path segment (got #{value.inspect})"
+      end
+    end
+  end
+end

--- a/lib/etlify/adapters/airtable_v0_adapter.rb
+++ b/lib/etlify/adapters/airtable_v0_adapter.rb
@@ -17,7 +17,6 @@ module Etlify
     #   adapter.batch_delete!(object_type: "tblXXX", crm_ids: ["recAAA", "recBBB"])
     class AirtableV0Adapter
       BATCH_MAX_SIZE = 10
-      SAFE_PATH_SEGMENT = /\A[\w\-]+\z/
 
       def rate_limiter
         @client.rate_limiter
@@ -46,7 +45,7 @@ module Etlify
       # For bulk operations, prefer batch_upsert! which uses
       # Airtable's native performUpsert (up to 10 rec/req).
       def upsert!(object_type:, payload:, id_property: nil, crm_id: nil)
-        validate_path_segment!(:object_type, object_type)
+        validate_string!(:object_type, object_type)
         raise ArgumentError, "payload must be a Hash" unless payload.is_a?(Hash)
 
         properties = payload.dup
@@ -63,10 +62,10 @@ module Etlify
       end
 
       def delete!(object_type:, crm_id:)
-        validate_path_segment!(:object_type, object_type)
-        validate_path_segment!(:crm_id, crm_id)
+        validate_string!(:object_type, object_type)
+        validate_string!(:crm_id, crm_id)
 
-        path = "#{@client.base_path(object_type)}/#{crm_id}"
+        path = @client.record_path(object_type, crm_id)
         response = @client.delete(path)
 
         return true if response[:status].between?(200, 299)
@@ -82,9 +81,9 @@ module Etlify
       # partial success when processing large batches.
       # @return [Hash{String => String}] mapping of id_property value to Airtable record ID
       def batch_upsert!(object_type:, records:, id_property:)
-        validate_path_segment!(:object_type, object_type)
+        validate_string!(:object_type, object_type)
         validate_present!(:id_property, id_property)
-        unless records.is_a?(Array) && !records.empty?
+        if !records.is_a?(Array) || records.empty?
           raise ArgumentError,
                 "records must be a non-empty Array"
         end
@@ -109,9 +108,10 @@ module Etlify
       # Note: if a later slice fails, records from earlier
       # slices are already deleted. Callers should handle
       # partial success when processing large batches.
+      # @return [Array<Hash>] Airtable record hashes (with deleted: true)
       def batch_delete!(object_type:, crm_ids:)
-        validate_path_segment!(:object_type, object_type)
-        unless crm_ids.is_a?(Array) && !crm_ids.empty?
+        validate_string!(:object_type, object_type)
+        if !crm_ids.is_a?(Array) || crm_ids.empty?
           raise ArgumentError,
                 "crm_ids must be a non-empty Array"
         end
@@ -164,7 +164,7 @@ module Etlify
       end
 
       def update_record(object_type, record_id, payload)
-        path = "#{@client.base_path(object_type)}/#{record_id}"
+        path = @client.record_path(object_type, record_id)
         response = @client.patch(path, body: {fields: stringify_keys(payload)})
         @client.raise_for_error!(response, path: path)
         true
@@ -225,12 +225,6 @@ module Etlify
         return unless value.nil? || value.to_s.empty?
 
         raise ArgumentError, "#{name} must be provided"
-      end
-
-      def validate_path_segment!(name, value)
-        return if value.is_a?(String) && value.match?(SAFE_PATH_SEGMENT)
-
-        raise ArgumentError, "#{name} must be a safe path segment (got #{value.inspect})"
       end
     end
   end

--- a/spec/adapters/airtable_v0/client_spec.rb
+++ b/spec/adapters/airtable_v0/client_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+require "etlify/adapters/airtable_v0/client"
+
+RSpec.describe Etlify::Adapters::AirtableV0::Client do
+  let(:token)   { "pat-test-token" }
+  let(:base_id) { "appTEST123456" }
+  let(:http)    { instance_double("HttpClient") }
+
+  subject(:client) do
+    described_class.new(
+      access_token: token,
+      base_id: base_id,
+      http: http
+    )
+  end
+
+  describe "#base_path" do
+    it "returns the base path for a table ID" do
+      expect(client.base_path("tblContacts"))
+        .to eq("/appTEST123456/tblContacts")
+    end
+
+    it "URL-encodes table names with spaces" do
+      expect(client.base_path("My Contacts"))
+        .to eq("/appTEST123456/My%20Contacts")
+    end
+
+    it "URL-encodes path traversal attempts" do
+      path = client.base_path("../../etc/passwd")
+      expect(path).not_to include("/../")
+      expect(path).to include("%2F")
+    end
+  end
+
+  describe "#record_path" do
+    it "returns the path for a specific record" do
+      expect(client.record_path("tblX", "recABC"))
+        .to eq("/appTEST123456/tblX/recABC")
+    end
+
+    it "URL-encodes the record ID" do
+      path = client.record_path("tblX", "../../secret")
+      expect(path).not_to include("/../")
+    end
+  end
+
+  describe "#raise_for_error!" do
+    it "does nothing on 2xx status" do
+      response = {status: 200, json: {}, body: "{}"}
+      expect { client.raise_for_error!(response, path: "/test") }
+        .not_to raise_error
+    end
+
+    it "raises Unauthorized on 401" do
+      response = {
+        status: 401,
+        json: {
+          "error" => {
+            "type" => "AUTHENTICATION_REQUIRED",
+            "message" => "No auth",
+          },
+        },
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::Unauthorized, /No auth/)
+    end
+
+    it "raises Unauthorized on 403" do
+      response = {
+        status: 403,
+        json: {
+          "error" => {
+            "type" => "FORBIDDEN",
+            "message" => "Access denied",
+          },
+        },
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::Unauthorized, /Access denied/)
+    end
+
+    it "raises NotFound on 404" do
+      response = {
+        status: 404,
+        json: {"error" => {"type" => "NOT_FOUND", "message" => "Gone"}},
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::NotFound)
+    end
+
+    it "raises ValidationFailed on 422" do
+      response = {
+        status: 422,
+        json: {
+          "error" => {
+            "type" => "INVALID_REQUEST",
+            "message" => "Bad field",
+          },
+        },
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::ValidationFailed)
+    end
+
+    it "raises RateLimited on 429" do
+      response = {
+        status: 429,
+        json: {
+          "error" => {
+            "type" => "RATE_LIMIT_REACHED",
+            "message" => "Too many requests",
+          },
+        },
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::RateLimited)
+    end
+
+    it "raises ApiError on other status codes" do
+      response = {
+        status: 500,
+        json: {
+          "error" => {
+            "type" => "SERVER_ERROR",
+            "message" => "Server down",
+          },
+        },
+        body: "{}",
+      }
+      expect { client.raise_for_error!(response, path: "/test") }
+        .to raise_error(Etlify::ApiError, /Server down/)
+    end
+  end
+
+  describe "transport errors" do
+    it "wraps transport exceptions into TransportError" do
+      allow(http).to receive(:request)
+        .and_raise(StandardError.new("connection reset"))
+
+      expect { client.get("/test") }
+        .to raise_error(
+          Etlify::TransportError, /connection reset/
+        )
+    end
+  end
+
+  describe "rate limiter integration" do
+    it "calls throttle! before each request" do
+      limiter = instance_double(
+        Etlify::RateLimiter, throttle!: nil
+      )
+      client.rate_limiter = limiter
+
+      allow(http).to receive(:request).and_return(
+        {status: 200, body: "{}"}
+      )
+
+      client.get("/test")
+      expect(limiter).to have_received(:throttle!).once
+    end
+  end
+end

--- a/spec/adapters/airtable_v0/formula_spec.rb
+++ b/spec/adapters/airtable_v0/formula_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+require "etlify/adapters/airtable_v0/formula"
+
+RSpec.describe Etlify::Adapters::AirtableV0::Formula do
+  describe ".eq" do
+    it "builds an equality formula for a string value" do
+      result = described_class.eq("Email", "john@example.com")
+      expect(result).to eq('{Email} = "john@example.com"')
+    end
+
+    it "builds an equality formula for a numeric value" do
+      result = described_class.eq("Age", 25)
+      expect(result).to eq("{Age} = 25")
+    end
+
+    it "rejects field names with special characters" do
+      expect do
+        described_class.eq("} = 1) OR 1=1; //", "hack")
+      end.to raise_error(
+        ArgumentError, /Invalid Airtable field name/
+      )
+    end
+
+    it "rejects non-scalar values" do
+      expect do
+        described_class.eq("Email", ["a@b.com"])
+      end.to raise_error(
+        ArgumentError, /Formula value must be/
+      )
+    end
+  end
+
+  describe ".escape" do
+    it "quotes strings with double quotes" do
+      expect(described_class.escape("hello")).to eq('"hello"')
+    end
+
+    it "leaves numerics unquoted" do
+      expect(described_class.escape(42)).to eq("42")
+    end
+
+    it "escapes backslashes in string values" do
+      result = described_class.escape('back\\slash')
+      expect(result).to eq('"back\\\\slash"')
+    end
+
+    it "escapes double quotes in string values" do
+      result = described_class.escape('say "hi"')
+      expect(result).to eq('"say \\"hi\\""')
+    end
+
+    it "accepts symbols" do
+      expect(described_class.escape(:test)).to eq('"test"')
+    end
+
+    it "raises on non-scalar types" do
+      expect do
+        described_class.escape([1, 2])
+      end.to raise_error(ArgumentError, /Formula value must be/)
+    end
+  end
+end

--- a/spec/adapters/airtable_v0_adapter_spec.rb
+++ b/spec/adapters/airtable_v0_adapter_spec.rb
@@ -1,0 +1,1359 @@
+require "rails_helper"
+require "etlify/adapters/airtable_v0_adapter"
+
+RSpec.describe Etlify::Adapters::AirtableV0Adapter do
+  let(:token)   { "pat-test-token" }
+  let(:base_id) { "appTEST123456" }
+  let(:table)   { "tblContacts" }
+  let(:http)    { instance_double("HttpClient") }
+
+  subject(:adapter) do
+    described_class.new(
+      access_token: token,
+      base_id: base_id,
+      http_client: http
+    )
+  end
+
+  describe "#initialize" do
+    it "raises on blank access_token" do
+      expect do
+        described_class.new(access_token: "", base_id: base_id)
+      end.to raise_error(ArgumentError, /access_token/)
+    end
+
+    it "raises on blank base_id" do
+      expect do
+        described_class.new(access_token: token, base_id: "")
+      end.to raise_error(ArgumentError, /base_id/)
+    end
+  end
+
+  describe "#upsert!" do
+    context "when record exists (search by id_property)" do
+      it "PATCHes the record and returns its id",
+         :aggregate_failures do
+        # 1) Search via filterByFormula
+        expect(http).to receive(:request).with(
+          :get,
+          %r{airtable\.com/v0/#{base_id}/#{table}\?},
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: nil
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [{"id" => "recABC123", "fields" => {}}],
+            }.to_json,
+          }
+        )
+
+        # 2) Update
+        expect(http).to receive(:request).with(
+          :patch,
+          "https://api.airtable.com/v0/#{base_id}/#{table}/recABC123",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["fields"] == {
+              "Email" => "john@example.com",
+              "Name" => "John",
+            }
+          end
+        ).and_return({status: 200, body: "{}"})
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Email: "john@example.com", Name: "John"},
+          id_property: "Email"
+        )
+        expect(id).to eq("recABC123")
+      end
+    end
+
+    context "when crm_id is provided" do
+      it "skips search and PATCHes directly",
+         :aggregate_failures do
+        expect(http).not_to receive(:request).with(
+          :get, /filterByFormula/, anything
+        )
+
+        expect(http).to receive(:request).with(
+          :patch,
+          "https://api.airtable.com/v0/#{base_id}/#{table}/recDIRECT",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["fields"].is_a?(Hash) &&
+              json["fields"]["Name"] == "John"
+          end
+        ).and_return({status: 200, body: "{}"})
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Email: "john@example.com", Name: "John"},
+          id_property: "Email",
+          crm_id: "recDIRECT"
+        )
+        expect(id).to eq("recDIRECT")
+      end
+    end
+
+    context "when record does not exist" do
+      it "POSTs a new record and returns its id",
+         :aggregate_failures do
+        # 1) Search -> no results
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {status: 200, body: {records: []}.to_json}
+        )
+
+        # 2) Create
+        expect(http).to receive(:request).with(
+          :post,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["fields"] == {
+              "Email" => "new@example.com",
+              "Name" => "New",
+            }
+          end
+        ).and_return(
+          {status: 200, body: {id: "recNEW001"}.to_json}
+        )
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Email: "new@example.com", Name: "New"},
+          id_property: "Email"
+        )
+        expect(id).to eq("recNEW001")
+      end
+    end
+
+    context "when no id_property is provided" do
+      it "creates directly without searching",
+         :aggregate_failures do
+        expect(http).not_to receive(:request).with(
+          :get, anything, anything
+        )
+
+        expect(http).to receive(:request).with(
+          :post,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["fields"] == {"Name" => "Direct"}
+          end
+        ).and_return(
+          {status: 200, body: {id: "recDIR001"}.to_json}
+        )
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Name: "Direct"}
+        )
+        expect(id).to eq("recDIR001")
+      end
+    end
+
+    it "accepts string or symbol keys in payload",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :get, /filterByFormula/, anything
+      ).and_return(
+        {status: 200, body: {records: []}.to_json}
+      )
+
+      expect(http).to receive(:request).with(
+        :post,
+        "https://api.airtable.com/v0/#{base_id}/#{table}",
+        headers: hash_including(
+          "Authorization" => "Bearer #{token}"
+        ),
+        body: satisfy do |body|
+          json = JSON.parse(body)
+          json["fields"] == {
+            "Email" => "a@b.com",
+            "Name" => "A",
+          }
+        end
+      ).and_return(
+        {status: 200, body: {id: "recMIX001"}.to_json}
+      )
+
+      id = adapter.upsert!(
+        object_type: table,
+        payload: {"Email" => "a@b.com", :Name => "A"},
+        id_property: "Email"
+      )
+      expect(id).to eq("recMIX001")
+    end
+
+    it "raises on invalid arguments", :aggregate_failures do
+      expect do
+        adapter.upsert!(object_type: "", payload: {})
+      end.to raise_error(ArgumentError)
+
+      expect do
+        adapter.upsert!(
+          object_type: table, payload: "not a hash"
+        )
+      end.to raise_error(ArgumentError)
+    end
+
+    it "escapes double quotes in formula values" do
+      expect(http).to receive(:request).with(
+        :get,
+        satisfy do |url|
+          decoded = URI.decode_www_form_component(url)
+          decoded.include?('{Name} = "value with \\"quotes\\""')
+        end,
+        anything
+      ).and_return(
+        {status: 200, body: {records: []}.to_json}
+      )
+
+      expect(http).to receive(:request).with(
+        :post, anything, anything
+      ).and_return(
+        {status: 200, body: {id: "recESC"}.to_json}
+      )
+
+      adapter.upsert!(
+        object_type: table,
+        payload: {Name: 'value with "quotes"'},
+        id_property: "Name"
+      )
+    end
+
+    it "uses numeric value without quotes in formula" do
+      expect(http).to receive(:request).with(
+        :get,
+        satisfy do |url|
+          decoded = URI.decode_www_form_component(url)
+          decoded.include?("{Score} = 42")
+        end,
+        anything
+      ).and_return(
+        {status: 200, body: {records: []}.to_json}
+      )
+
+      expect(http).to receive(:request).with(
+        :post, anything, anything
+      ).and_return(
+        {status: 200, body: {id: "recNUM"}.to_json}
+      )
+
+      adapter.upsert!(
+        object_type: table,
+        payload: {Score: 42, Name: "Test"},
+        id_property: "Score"
+      )
+    end
+
+    context "when search returns 404" do
+      it "treats as not found and creates",
+         :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return({status: 404, body: ""})
+
+        expect(http).to receive(:request).with(
+          :post,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          anything
+        ).and_return(
+          {status: 200, body: {id: "rec404C"}.to_json}
+        )
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Email: "j@e.com", Name: "J"},
+          id_property: "Email"
+        )
+        expect(id).to eq("rec404C")
+      end
+    end
+
+    context "when search returns 401" do
+      it "raises Unauthorized" do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {
+            status: 401,
+            body: {
+              error: {
+                type: "AUTHENTICATION_REQUIRED",
+                message: "Invalid token",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::Unauthorized, /Invalid token.*status=401/
+        )
+      end
+    end
+
+    context "when update returns 422" do
+      it "raises ValidationFailed", :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [{"id" => "rec9"}],
+            }.to_json,
+          }
+        )
+
+        expect(http).to receive(:request).with(
+          :patch, /rec9/, anything
+        ).and_return(
+          {
+            status: 422,
+            body: {
+              error: {
+                type: "INVALID_REQUEST_UNKNOWN",
+                message: "Invalid fields",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "john@example.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::ValidationFailed, /Invalid fields/
+        )
+      end
+    end
+
+    context "when create returns 429" do
+      it "raises RateLimited", :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {status: 200, body: {records: []}.to_json}
+        )
+
+        expect(http).to receive(:request).with(
+          :post, anything, anything
+        ).and_return(
+          {
+            status: 429,
+            body: {
+              error: {
+                type: "RATE_LIMIT_REACHED",
+                message: "Too many requests",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "a@b.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::RateLimited, /Too many requests/
+        )
+      end
+    end
+
+    context "when search returns 500" do
+      it "raises ApiError" do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {
+            status: 500,
+            body: {
+              error: {
+                type: "SERVER_ERROR",
+                message: "Internal error",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::ApiError, /Internal error.*status=500/
+        )
+      end
+    end
+
+    context "when body is non-JSON" do
+      it "raises ApiError with generic message" do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {status: 500, body: "<html>oops</html>"}
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::ApiError,
+          /Airtable API request failed/
+        )
+      end
+    end
+
+    context "when transport layer fails" do
+      it "wraps into TransportError" do
+        expect(http).to receive(:request).and_raise(
+          StandardError.new("tcp reset")
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::TransportError, /tcp reset/
+        )
+      end
+    end
+
+    it "wraps transport errors during update",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :get, /filterByFormula/, anything
+      ).and_return(
+        {
+          status: 200,
+          body: {
+            records: [{"id" => "rec1"}],
+          }.to_json,
+        }
+      )
+
+      expect(http).to receive(:request).with(
+        :patch, /rec1/, anything
+      ).and_raise(StandardError.new("network down"))
+
+      expect do
+        adapter.upsert!(
+          object_type: table,
+          payload: {Email: "x@y.com", Name: "X"},
+          id_property: "Email"
+        )
+      end.to raise_error(
+        Etlify::TransportError, /network down/
+      )
+    end
+  end
+
+  describe "#delete!" do
+    it "returns true on 2xx response" do
+      expect(http).to receive(:request).with(
+        :delete,
+        "https://api.airtable.com/v0/#{base_id}/#{table}/recDEL1",
+        headers: hash_including(
+          "Authorization" => "Bearer #{token}"
+        ),
+        body: nil
+      ).and_return({status: 200, body: "{}"})
+
+      expect(
+        adapter.delete!(object_type: table, crm_id: "recDEL1")
+      ).to be true
+    end
+
+    it "returns false on 404 response" do
+      expect(http).to receive(:request).with(
+        :delete,
+        "https://api.airtable.com/v0/#{base_id}/#{table}/recGONE",
+        headers: hash_including(
+          "Authorization" => "Bearer #{token}"
+        ),
+        body: nil
+      ).and_return({status: 404, body: ""})
+
+      expect(
+        adapter.delete!(
+          object_type: table, crm_id: "recGONE"
+        )
+      ).to be false
+    end
+
+    it "raises on invalid arguments", :aggregate_failures do
+      expect do
+        adapter.delete!(object_type: "", crm_id: "rec1")
+      end.to raise_error(ArgumentError)
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: nil)
+      end.to raise_error(ArgumentError)
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: "")
+      end.to raise_error(ArgumentError)
+    end
+
+    it "raises ApiError on 400" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return(
+        {
+          status: 400,
+          body: {
+            error: {
+              type: "INVALID_REQUEST",
+              message: "Bad request",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: "rec1")
+      end.to raise_error(Etlify::ApiError, /Bad request/)
+    end
+
+    it "raises Unauthorized on 401" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return(
+        {
+          status: 401,
+          body: {
+            error: {
+              type: "AUTHENTICATION_REQUIRED",
+              message: "No auth",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: "rec1")
+      end.to raise_error(Etlify::Unauthorized)
+    end
+
+    it "raises ApiError on 500" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return(
+        {
+          status: 500,
+          body: {
+            error: {
+              type: "SERVER_ERROR",
+              message: "Server down",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: "rec1")
+      end.to raise_error(Etlify::ApiError, /Server down/)
+    end
+
+    it "wraps transport errors into TransportError" do
+      expect(http).to receive(:request).and_raise(
+        StandardError.new("network oops")
+      )
+
+      expect do
+        adapter.delete!(object_type: table, crm_id: "rec1")
+      end.to raise_error(
+        Etlify::TransportError, /network oops/
+      )
+    end
+  end
+
+  describe "#batch_upsert!" do
+    context "with a single batch (<= 10 records)" do
+      it "sends one PATCH with performUpsert and returns records",
+         :aggregate_failures do
+        records = [
+          {Email: "a@b.com", Name: "A"},
+          {Email: "c@d.com", Name: "C"},
+        ]
+
+        expect(http).to receive(:request).with(
+          :patch,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["performUpsert"]["fieldsToMergeOn"] == ["Email"] &&
+              json["records"].size == 2 &&
+              json["records"][0]["fields"]["Email"] == "a@b.com" &&
+              json["records"][1]["fields"]["Email"] == "c@d.com"
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [
+                {
+                  "id" => "recA",
+                  "createdTime" => "2024-01-01",
+                  "fields" => {"Email" => "a@b.com"},
+                },
+                {
+                  "id" => "recC",
+                  "createdTime" => "2024-01-01",
+                  "fields" => {"Email" => "c@d.com"},
+                },
+              ],
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: "Email"
+        )
+        expect(result).to eq(
+          "a@b.com" => "recA",
+          "c@d.com" => "recC"
+        )
+      end
+    end
+
+    context "with multiple batches (> 10 records)" do
+      it "splits into slices of 10", :aggregate_failures do
+        records = (1..12).map do |i|
+          {Email: "u#{i}@test.com", Name: "U#{i}"}
+        end
+
+        # First batch: 10 records
+        expect(http).to receive(:request).with(
+          :patch,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            JSON.parse(body)["records"].size == 10
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (1..10).map do |i|
+                {"id" => "rec#{i}", "fields" => {"Email" => "u#{i}@test.com"}}
+              end,
+            }.to_json,
+          }
+        )
+
+        # Second batch: 2 records
+        expect(http).to receive(:request).with(
+          :patch,
+          "https://api.airtable.com/v0/#{base_id}/#{table}",
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: satisfy do |body|
+            JSON.parse(body)["records"].size == 2
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (11..12).map do |i|
+                {"id" => "rec#{i}", "fields" => {"Email" => "u#{i}@test.com"}}
+              end,
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: "Email"
+        )
+        expect(result).to be_a(Hash)
+        expect(result.size).to eq(12)
+      end
+    end
+
+    it "raises on invalid arguments", :aggregate_failures do
+      expect do
+        adapter.batch_upsert!(
+          object_type: "", records: [{}], id_property: "Email"
+        )
+      end.to raise_error(ArgumentError, /object_type/)
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: table, records: [], id_property: "Email"
+        )
+      end.to raise_error(ArgumentError, /records/)
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: table, records: [{}], id_property: ""
+        )
+      end.to raise_error(ArgumentError, /id_property/)
+    end
+
+    it "raises RateLimited on 429" do
+      expect(http).to receive(:request).with(
+        :patch, anything, anything
+      ).and_return(
+        {
+          status: 429,
+          body: {
+            error: {
+              type: "RATE_LIMIT_REACHED",
+              message: "Too many requests",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: table,
+          records: [{Email: "a@b.com"}],
+          id_property: "Email"
+        )
+      end.to raise_error(
+        Etlify::RateLimited, /Too many requests/
+      )
+    end
+
+    it "raises ValidationFailed on 422" do
+      expect(http).to receive(:request).with(
+        :patch, anything, anything
+      ).and_return(
+        {
+          status: 422,
+          body: {
+            error: {
+              type: "INVALID_REQUEST_UNKNOWN",
+              message: "Invalid fields",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: table,
+          records: [{Email: "a@b.com"}],
+          id_property: "Email"
+        )
+      end.to raise_error(
+        Etlify::ValidationFailed, /Invalid fields/
+      )
+    end
+  end
+
+  describe "#batch_delete!" do
+    context "with a single batch (<= 10 IDs)" do
+      it "sends one DELETE and returns results",
+         :aggregate_failures do
+        crm_ids = ["recA", "recB", "recC"]
+
+        expect(http).to receive(:request).with(
+          :delete,
+          satisfy do |url|
+            url.include?("records%5B%5D=recA") ||
+              url.include?("records[]=recA")
+          end,
+          headers: hash_including(
+            "Authorization" => "Bearer #{token}"
+          ),
+          body: nil
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [
+                {"id" => "recA", "deleted" => true},
+                {"id" => "recB", "deleted" => true},
+                {"id" => "recC", "deleted" => true},
+              ],
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_delete!(
+          object_type: table, crm_ids: crm_ids
+        )
+        expect(result.size).to eq(3)
+        expect(result.all? { |r| r["deleted"] == true }).to be true
+      end
+    end
+
+    context "with multiple batches (> 10 IDs)" do
+      it "splits into slices of 10", :aggregate_failures do
+        crm_ids = (1..12).map { |i| "rec#{i}" }
+
+        # First batch: 10 IDs
+        expect(http).to receive(:request).with(
+          :delete,
+          satisfy { |url| url.include?("rec1") },
+          anything
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (1..10).map do |i|
+                {"id" => "rec#{i}", "deleted" => true}
+              end,
+            }.to_json,
+          }
+        )
+
+        # Second batch: 2 IDs
+        expect(http).to receive(:request).with(
+          :delete,
+          satisfy { |url| url.include?("rec11") },
+          anything
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (11..12).map do |i|
+                {"id" => "rec#{i}", "deleted" => true}
+              end,
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_delete!(
+          object_type: table, crm_ids: crm_ids
+        )
+        expect(result.size).to eq(12)
+      end
+    end
+
+    it "raises on invalid arguments", :aggregate_failures do
+      expect do
+        adapter.batch_delete!(
+          object_type: "", crm_ids: ["rec1"]
+        )
+      end.to raise_error(ArgumentError, /object_type/)
+
+      expect do
+        adapter.batch_delete!(
+          object_type: table, crm_ids: []
+        )
+      end.to raise_error(ArgumentError, /crm_ids/)
+    end
+
+    it "raises RateLimited on 429" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return(
+        {
+          status: 429,
+          body: {
+            error: {
+              type: "RATE_LIMIT_REACHED",
+              message: "Too many requests",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: table, crm_ids: ["rec1"]
+        )
+      end.to raise_error(
+        Etlify::RateLimited, /Too many requests/
+      )
+    end
+
+    it "raises ApiError on 500" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return(
+        {
+          status: 500,
+          body: {
+            error: {
+              type: "SERVER_ERROR",
+              message: "Server down",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: table, crm_ids: ["rec1"]
+        )
+      end.to raise_error(Etlify::ApiError, /Server down/)
+    end
+
+    it "wraps transport errors into TransportError" do
+      expect(http).to receive(:request).and_raise(
+        StandardError.new("connection refused")
+      )
+
+      expect do
+        adapter.batch_delete!(
+          object_type: table, crm_ids: ["rec1"]
+        )
+      end.to raise_error(
+        Etlify::TransportError, /connection refused/
+      )
+    end
+  end
+
+  describe "edge cases" do
+    context "when crm_id is whitespace-only" do
+      it "treats as absent and searches by id_property",
+         :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {status: 200, body: {records: []}.to_json}
+        )
+
+        expect(http).to receive(:request).with(
+          :post, anything, anything
+        ).and_return(
+          {status: 200, body: {id: "recWS"}.to_json}
+        )
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Email: "a@b.com"},
+          id_property: "Email",
+          crm_id: "   "
+        )
+        expect(id).to eq("recWS")
+      end
+    end
+
+    context "when id_property is provided but absent from payload" do
+      it "creates directly without searching",
+         :aggregate_failures do
+        expect(http).not_to receive(:request).with(
+          :get, anything, anything
+        )
+
+        expect(http).to receive(:request).with(
+          :post, anything, anything
+        ).and_return(
+          {status: 200, body: {id: "recNOKEY"}.to_json}
+        )
+
+        id = adapter.upsert!(
+          object_type: table,
+          payload: {Name: "Test"},
+          id_property: "Email"
+        )
+        expect(id).to eq("recNOKEY")
+      end
+    end
+
+    context "when create returns 2xx but no id in response" do
+      it "raises ApiError", :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :post, anything, anything
+        ).and_return(
+          {status: 200, body: {fields: {}}.to_json}
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Name: "NoId"}
+          )
+        end.to raise_error(Etlify::ApiError)
+      end
+    end
+
+    context "when transport layer fails during create" do
+      it "wraps into TransportError", :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {status: 200, body: {records: []}.to_json}
+        )
+
+        expect(http).to receive(:request).with(
+          :post, anything, anything
+        ).and_raise(StandardError.new("connection reset"))
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "a@b.com", Name: "A"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::TransportError, /connection reset/
+        )
+      end
+    end
+
+    context "when search returns 403" do
+      it "raises Unauthorized" do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {
+            status: 403,
+            body: {
+              error: {
+                type: "FORBIDDEN",
+                message: "Access denied",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(Etlify::Unauthorized, /Access denied/)
+      end
+    end
+
+    context "when delete! returns 403" do
+      it "raises Unauthorized" do
+        expect(http).to receive(:request).with(
+          :delete, anything, anything
+        ).and_return(
+          {
+            status: 403,
+            body: {
+              error: {
+                type: "FORBIDDEN",
+                message: "No access",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.delete!(
+            object_type: table, crm_id: "rec1"
+          )
+        end.to raise_error(Etlify::Unauthorized, /No access/)
+      end
+    end
+
+    context "when batch response is missing records key" do
+      it "batch_upsert! returns empty hash",
+         :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :patch, anything, anything
+        ).and_return(
+          {status: 200, body: {}.to_json}
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: [{Email: "a@b.com"}],
+          id_property: "Email"
+        )
+        expect(result).to eq({})
+      end
+
+      it "batch_delete! returns empty array",
+         :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :delete, anything, anything
+        ).and_return(
+          {status: 200, body: {}.to_json}
+        )
+
+        result = adapter.batch_delete!(
+          object_type: table, crm_ids: ["rec1"]
+        )
+        expect(result).to eq([])
+      end
+    end
+
+    context "when batch_upsert! transport fails" do
+      it "wraps into TransportError" do
+        expect(http).to receive(:request).and_raise(
+          StandardError.new("batch timeout")
+        )
+
+        expect do
+          adapter.batch_upsert!(
+            object_type: table,
+            records: [{Email: "a@b.com"}],
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::TransportError, /batch timeout/
+        )
+      end
+    end
+
+    context "when update returns 409" do
+      it "raises ValidationFailed", :aggregate_failures do
+        expect(http).to receive(:request).with(
+          :get, /filterByFormula/, anything
+        ).and_return(
+          {
+            status: 200,
+            body: {records: [{"id" => "rec9"}]}.to_json,
+          }
+        )
+
+        expect(http).to receive(:request).with(
+          :patch, /rec9/, anything
+        ).and_return(
+          {
+            status: 409,
+            body: {
+              error: {
+                type: "CONFLICT",
+                message: "Record conflict",
+              },
+            }.to_json,
+          }
+        )
+
+        expect do
+          adapter.upsert!(
+            object_type: table,
+            payload: {Email: "x@y.com"},
+            id_property: "Email"
+          )
+        end.to raise_error(
+          Etlify::ValidationFailed, /Record conflict/
+        )
+      end
+    end
+
+    context "when initialize receives non-string types" do
+      it "raises ArgumentError for numeric access_token" do
+        expect do
+          described_class.new(
+            access_token: 12345, base_id: "appXXX"
+          )
+        end.to raise_error(ArgumentError, /access_token/)
+      end
+
+      it "raises ArgumentError for nil base_id" do
+        expect do
+          described_class.new(
+            access_token: "token", base_id: nil
+          )
+        end.to raise_error(ArgumentError, /base_id/)
+      end
+    end
+  end
+
+  describe "formula validation" do
+    it "rejects field names with special characters" do
+      expect do
+        adapter.upsert!(
+          object_type: table,
+          payload: {"} = 1) OR 1=1; //" => "hack"},
+          id_property: "} = 1) OR 1=1; //"
+        )
+      end.to raise_error(
+        ArgumentError, /Invalid Airtable field name/
+      )
+    end
+
+    it "rejects non-scalar formula values" do
+      expect do
+        adapter.upsert!(
+          object_type: table,
+          payload: {Email: ["a@b.com"]},
+          id_property: "Email"
+        )
+      end.to raise_error(
+        ArgumentError, /Formula value must be/
+      )
+    end
+  end
+
+  describe "path traversal protection" do
+    it "rejects object_type with path traversal" do
+      expect do
+        adapter.upsert!(
+          object_type: "../etc/passwd",
+          payload: {Name: "hack"}
+        )
+      end.to raise_error(
+        ArgumentError, /object_type.*safe path segment/
+      )
+    end
+
+    it "rejects crm_id with path traversal" do
+      expect do
+        adapter.delete!(
+          object_type: table, crm_id: "../../secret"
+        )
+      end.to raise_error(
+        ArgumentError, /crm_id.*safe path segment/
+      )
+    end
+
+    it "accepts valid Airtable record IDs" do
+      expect(http).to receive(:request).with(
+        :delete, anything, anything
+      ).and_return({status: 200, body: "{}"})
+
+      expect(
+        adapter.delete!(
+          object_type: table, crm_id: "recABC123xyz"
+        )
+      ).to be true
+    end
+  end
+
+  describe "backslash escaping in formulas" do
+    it "escapes backslashes in formula values" do
+      expect(http).to receive(:request).with(
+        :get,
+        satisfy do |url|
+          decoded = URI.decode_www_form_component(url)
+          decoded.include?('{Name} = "back\\\\slash"')
+        end,
+        anything
+      ).and_return(
+        {status: 200, body: {records: []}.to_json}
+      )
+
+      expect(http).to receive(:request).with(
+        :post, anything, anything
+      ).and_return(
+        {status: 200, body: {id: "recBS"}.to_json}
+      )
+
+      adapter.upsert!(
+        object_type: table,
+        payload: {Name: 'back\\slash'},
+        id_property: "Name"
+      )
+    end
+  end
+
+  describe "batch edge cases" do
+    it "batch_upsert! accepts id_property as Symbol",
+       :aggregate_failures do
+      expect(http).to receive(:request).with(
+        :patch,
+        anything,
+        headers: anything,
+        body: satisfy do |body|
+          json = JSON.parse(body)
+          json["performUpsert"]["fieldsToMergeOn"] == ["Email"]
+        end
+      ).and_return(
+        {
+          status: 200,
+          body: {
+            records: [{"id" => "recSYM", "fields" => {"Email" => "a@b.com"}}],
+          }.to_json,
+        }
+      )
+
+      result = adapter.batch_upsert!(
+        object_type: table,
+        records: [{Email: "a@b.com"}],
+        id_property: :Email
+      )
+      expect(result).to eq("a@b.com" => "recSYM")
+    end
+
+    it "batch raises on 2nd slice after 1st succeeds",
+       :aggregate_failures do
+      records = (1..12).map do |i|
+        {Email: "u#{i}@test.com"}
+      end
+
+      # 1st slice succeeds
+      expect(http).to receive(:request).with(
+        :patch, anything,
+        headers: anything,
+        body: satisfy { |b| JSON.parse(b)["records"].size == 10 }
+      ).and_return(
+        {
+          status: 200,
+          body: {
+            records: (1..10).map do |i|
+              {"id" => "rec#{i}", "fields" => {}}
+            end,
+          }.to_json,
+        }
+      )
+
+      # 2nd slice rate limited
+      expect(http).to receive(:request).with(
+        :patch, anything,
+        headers: anything,
+        body: satisfy { |b| JSON.parse(b)["records"].size == 2 }
+      ).and_return(
+        {
+          status: 429,
+          body: {
+            error: {
+              type: "RATE_LIMIT_REACHED",
+              message: "Too many requests",
+            },
+          }.to_json,
+        }
+      )
+
+      expect do
+        adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: "Email"
+        )
+      end.to raise_error(Etlify::RateLimited)
+    end
+  end
+end

--- a/spec/adapters/airtable_v0_adapter_spec.rb
+++ b/spec/adapters/airtable_v0_adapter_spec.rb
@@ -1192,90 +1192,30 @@ RSpec.describe Etlify::Adapters::AirtableV0Adapter do
     end
   end
 
-  describe "formula validation" do
-    it "rejects field names with special characters" do
-      expect do
-        adapter.upsert!(
-          object_type: table,
-          payload: {"} = 1) OR 1=1; //" => "hack"},
-          id_property: "} = 1) OR 1=1; //"
-        )
-      end.to raise_error(
-        ArgumentError, /Invalid Airtable field name/
-      )
-    end
-
-    it "rejects non-scalar formula values" do
-      expect do
-        adapter.upsert!(
-          object_type: table,
-          payload: {Email: ["a@b.com"]},
-          id_property: "Email"
-        )
-      end.to raise_error(
-        ArgumentError, /Formula value must be/
-      )
-    end
-  end
-
-  describe "path traversal protection" do
-    it "rejects object_type with path traversal" do
-      expect do
-        adapter.upsert!(
-          object_type: "../etc/passwd",
-          payload: {Name: "hack"}
-        )
-      end.to raise_error(
-        ArgumentError, /object_type.*safe path segment/
-      )
-    end
-
-    it "rejects crm_id with path traversal" do
-      expect do
-        adapter.delete!(
-          object_type: table, crm_id: "../../secret"
-        )
-      end.to raise_error(
-        ArgumentError, /crm_id.*safe path segment/
-      )
-    end
-
-    it "accepts valid Airtable record IDs" do
+  describe "URL encoding of path segments" do
+    it "URL-encodes object_type with spaces" do
       expect(http).to receive(:request).with(
-        :delete, anything, anything
+        :post, /My%20Contacts/, anything
+      ).and_return(
+        {status: 200, body: {id: "recSPC"}.to_json}
+      )
+
+      id = adapter.upsert!(
+        object_type: "My Contacts",
+        payload: {Name: "Test"}
+      )
+      expect(id).to eq("recSPC")
+    end
+
+    it "URL-encodes path traversal attempts" do
+      expect(http).to receive(:request).with(
+        :delete,
+        satisfy { |url| !url.include?("/../") },
+        anything
       ).and_return({status: 200, body: "{}"})
 
-      expect(
-        adapter.delete!(
-          object_type: table, crm_id: "recABC123xyz"
-        )
-      ).to be true
-    end
-  end
-
-  describe "backslash escaping in formulas" do
-    it "escapes backslashes in formula values" do
-      expect(http).to receive(:request).with(
-        :get,
-        satisfy do |url|
-          decoded = URI.decode_www_form_component(url)
-          decoded.include?('{Name} = "back\\\\slash"')
-        end,
-        anything
-      ).and_return(
-        {status: 200, body: {records: []}.to_json}
-      )
-
-      expect(http).to receive(:request).with(
-        :post, anything, anything
-      ).and_return(
-        {status: 200, body: {id: "recBS"}.to_json}
-      )
-
-      adapter.upsert!(
-        object_type: table,
-        payload: {Name: 'back\\slash'},
-        id_property: "Name"
+      adapter.delete!(
+        object_type: table, crm_id: "../../secret"
       )
     end
   end


### PR DESCRIPTION
## Nouvelles fonctionnalités

- **AirtableV0Adapter** : adapter complet pour l'API Airtable v0 avec `upsert!`, `delete!`, `batch_upsert!` (via `performUpsert` natif, 10 records/requête) et `batch_delete!`.
- **Zero dépendance externe** : utilise `Net::HTTP` via le `DefaultHttp` partagé.
- **Rate limiting intégré** : support du `rate_limiter=` sur le `Client` interne, compatible avec le `BatchSyncJob`.
- **Gestion d'erreurs structurée** : mapping HTTP → hiérarchie Etlify (401→Unauthorized, 429→RateLimited, etc.).

## Gains de performance (Airtable)

| Métrique | Avant (upsert! unitaire) | Après (batch_upsert!) |
|----------|--------------------------|----------------------|
| Requêtes API par sync | 1-2 par record (search + create/update) | 1 par tranche de 10 records |
| Débit effectif (5 req/s/base) | ~2-5 records/s | ~50 records/s |
| Jobs Sidekiq | N/A (même BatchSyncJob) | 1 par CRM |

Pour 1 000 records stale, on passe de ~1 000-2 000 requêtes API à ~100.