### PR TITLE
Add BrevoAdapter for Brevo CRM API v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Feat: Add `Etlify::BatchSynchronizer` — batch-aware synchronizer that applies per-record pre-checks (guard, digest, dependencies) then calls `adapter.batch_upsert!` for all ready records. Used by `BatchSyncJob` when the adapter supports it, with fallback to sequential `Synchronizer.call`.
 - Feat: Adapters now support an optional `rate_limiter=` accessor for per-HTTP-request throttling.
 - Feat: Add `batch_upsert!` and `batch_delete!` to `NullAdapter` for test support.
+- Feat: Add `BrevoAdapter` for Brevo (ex-Sendinblue) API v3. Supports contacts, companies, and deals via `upsert!` and `delete!`. Uses `Net::HTTP` (zero external dependency), injectable `http_client:` for testing, and structured error handling via the Etlify error hierarchy. Supports rate limiting via `rate_limiter=` accessor. No `batch_upsert!` (Brevo batch import is async/incompatible).
 
 # V0.9.4
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Etlify sits beside your app; it does **not** try to own your domain or backgroun
 | ----------- | ------------------------------------------------------------- | --------------------------------------------------- |
 | DSL         | `include Etlify::Model` + `etlified_with(...)` on your models | Opt-in sync with a single line; clear, local intent |
 | Serialisers | A base class to turn a model into a CRM payload               | Keeps mapping logic where it belongs; easy to test  |
-| Adapters    | HubSpot adapter included; plug your own                       | Swap CRMs without touching model code               |
+| Adapters    | HubSpot & Brevo adapters included; plug your own              | Swap CRMs without touching model code               |
 | Idempotence | Stable digest of the last synced payload                      | Avoids redundant API calls; safe to retry           |
 | Jobs        | `crm_sync!` enqueues an ActiveJob; batch sync via `BatchSyncJob` | Fits your queue; built-in rate limiting              |
 | Delete      | `crm_delete!` to remove a record from the CRM                 | Keeps both sides consistent                         |
@@ -521,6 +521,56 @@ adapter.batch_delete!(
 
 ---
 
+## Brevo adapter (API v3)
+
+Etlify ships with `Etlify::Adapters::BrevoAdapter` for Brevo (ex-Sendinblue). It supports contacts, companies, and deals.
+
+### Configuration
+
+```ruby
+Etlify.configure do |config|
+  Etlify::CRM.register(
+    :brevo,
+    adapter: Etlify::Adapters::BrevoAdapter.new(
+      api_key: ENV["BREVO_API_KEY"]
+    ),
+    options: {
+      rate_limit: { max_requests: 100, period: 3600 },
+    }
+  )
+end
+```
+
+### Behaviour
+
+- `object_type`: `"contacts"`, `"companies"`, or `"deals"`.
+- `id_property`: for contacts, use `"email"` (default lookup) or `"ext_id"` (external identifier). Companies and deals require `crm_id` for updates.
+- Contact upsert: searches by email (or ext_id), then creates or updates.
+
+### Example
+
+```ruby
+class User < ApplicationRecord
+  include Etlify::Model
+
+  brevo_etlified_with(
+    serializer: UserBrevoSerializer,
+    crm_object_type: "contacts",
+    id_property: :email,
+    sync_if: ->(user) { user.email.present? }
+  )
+end
+
+# Later
+user.brevo_sync!
+```
+
+> **Note:** Brevo's batch import endpoint is asynchronous and incompatible with Etlify's synchronous `batch_upsert!` interface. `BatchSyncJob` falls back to sequential `Synchronizer.call` for Brevo.
+
+> **Rate limiting:** Brevo enforces 100 requests/hour (standard plan). Configure `rate_limit` accordingly.
+
+---
+
 ## Writing your own adapter
 
 Implement the following interface:
@@ -628,6 +678,7 @@ expect(fake_adapter).to have_received(:upsert!).with(
 
 - `Etlify::Adapters::NullAdapter` (default; no-op)
 - `Etlify::Adapters::HubspotV3Adapter` (API v3, with batch support)
+- `Etlify::Adapters::BrevoAdapter` (API v3, contacts/companies/deals)
 
 ---
 

--- a/lib/etlify/adapters.rb
+++ b/lib/etlify/adapters.rb
@@ -1,2 +1,3 @@
 require_relative "adapters/null_adapter"
 require_relative "adapters/hubspot_v3_adapter"
+require_relative "adapters/brevo_adapter"

--- a/lib/etlify/adapters/brevo/client.rb
+++ b/lib/etlify/adapters/brevo/client.rb
@@ -1,0 +1,116 @@
+require "json"
+require "uri"
+
+module Etlify
+  module Adapters
+    module Brevo
+      # Low-level HTTP client for the Brevo API v3.
+      # Handles request building, authentication, JSON
+      # parsing, and error mapping.
+      class Client
+        API_BASE = "https://api.brevo.com/v3"
+
+        attr_accessor :rate_limiter
+
+        def initialize(api_key:, http:)
+          @api_key = api_key
+          @http    = http
+        end
+
+        def get(path, query: {})
+          request(:get, path, query: query)
+        end
+
+        def post(path, body:)
+          request(:post, path, body: body)
+        end
+
+        def put(path, body:)
+          request(:put, path, body: body)
+        end
+
+        def patch(path, body:)
+          request(:patch, path, body: body)
+        end
+
+        def delete(path)
+          request(:delete, path)
+        end
+
+        def raise_for_error!(response, path:)
+          status = response[:status].to_i
+          return if status.between?(200, 299)
+
+          body = response[:json].is_a?(Hash) ? response[:json] : {}
+          message = body["message"] || "Brevo API request failed"
+          code = body["code"] || body["error"]
+
+          full_message = "#{message} (status=#{status}, path=#{path}"
+          full_message << ", code=#{code}" if code
+          full_message << ")"
+
+          error_class =
+            case status
+            when 401, 403 then Etlify::Unauthorized
+            when 404      then Etlify::NotFound
+            when 409, 422 then Etlify::ValidationFailed
+            when 429      then Etlify::RateLimited
+            else Etlify::ApiError
+            end
+
+          raise error_class.new(
+            full_message,
+            status: status,
+            code: code,
+            category: nil,
+            correlation_id: nil,
+            details: body,
+            raw: response[:body]
+          )
+        end
+
+        private
+
+        def request(method, path, body: nil, query: {})
+          @rate_limiter&.throttle!
+
+          url = API_BASE + path
+          unless query.empty?
+            url += "?#{URI.encode_www_form(query)}"
+          end
+
+          headers = {
+            "api-key" => @api_key,
+            "Content-Type" => "application/json",
+            "Accept" => "application/json",
+          }
+
+          raw_body = body && JSON.dump(body)
+
+          begin
+            response = @http.request(
+              method, url, headers: headers, body: raw_body
+            )
+          rescue => exception
+            raise Etlify::TransportError.new(
+              "HTTP transport error: #{exception.class}: #{exception.message}",
+              status: 0,
+              raw: nil
+            )
+          end
+
+          response[:json] = parse_json_safe(response[:body])
+          response
+        end
+
+        def parse_json_safe(raw_body)
+          return nil if raw_body.nil? || raw_body.empty?
+
+          JSON.parse(raw_body)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/etlify/adapters/brevo_adapter.rb
+++ b/lib/etlify/adapters/brevo_adapter.rb
@@ -1,0 +1,228 @@
+require_relative "default_http"
+require_relative "brevo/client"
+
+module Etlify
+  module Adapters
+    # Brevo Adapter (API v3) for contacts, companies, and deals.
+    #
+    # Usage:
+    #   adapter = Etlify::Adapters::BrevoAdapter.new(
+    #     api_key: ENV["BREVO_API_KEY"],
+    #   )
+    #   adapter.upsert!(object_type: "contacts", payload: {email: "john@example.com"}, id_property: :email)
+    #   adapter.delete!(object_type: "contacts", crm_id: "42")
+    class BrevoAdapter
+      IDENTIFIER_TYPE_MAP = {
+        "email" => "email_id",
+        "ext_id" => "ext_id",
+        "phone" => "phone_id",
+        "sms" => "phone_id",
+      }.freeze
+
+      OBJECT_PATHS = {
+        "contacts" => "/contacts",
+        "companies" => "/companies",
+        "deals" => "/crm/deals",
+      }.freeze
+
+      def initialize(api_key:, http_client: nil)
+        validate_string!(:api_key, api_key)
+
+        @client = Brevo::Client.new(
+          api_key: api_key,
+          http: http_client || DefaultHttp.new
+        )
+      end
+
+      def rate_limiter
+        @client.rate_limiter
+      end
+
+      def rate_limiter=(limiter)
+        @client.rate_limiter = limiter
+      end
+
+      # Etlify adapter interface.
+      # @return [String] CRM ID
+      def upsert!(object_type:, payload:, id_property: nil, crm_id: nil)
+        validate_object_type!(object_type)
+        raise ArgumentError, "payload must be a Hash" unless payload.is_a?(Hash)
+
+        properties = stringify_keys(payload)
+
+        object_id = resolve_object_id(
+          object_type, properties, id_property, crm_id
+        )
+
+        if object_id
+          update_record(object_type, object_id, properties)
+          object_id.to_s
+        else
+          create_record(object_type, properties)
+        end
+      end
+
+      # Etlify adapter interface.
+      # @return [Boolean]
+      def delete!(object_type:, crm_id:)
+        validate_object_type!(object_type)
+        raise ArgumentError, "crm_id must be provided" if crm_id.nil? || crm_id.to_s.empty?
+
+        path = "#{base_path(object_type)}/#{crm_id}"
+        response = @client.delete(path)
+
+        return true if response[:status].between?(200, 299)
+        return false if response[:status] == 404
+
+        @client.raise_for_error!(response, path: path)
+      end
+
+      private
+
+      def base_path(object_type)
+        OBJECT_PATHS.fetch(object_type) do
+          message = [
+            "Unsupported object_type: #{object_type.inspect}.",
+            "Supported: #{OBJECT_PATHS.keys.join(', ')}",
+          ].join(" ")
+          raise ArgumentError, message
+        end
+      end
+
+      def resolve_object_id(object_type, properties, id_property, crm_id)
+        unless crm_id.to_s.strip.empty?
+          return crm_id.to_s.strip
+        end
+
+        return nil unless id_property
+
+        key = id_property.to_s
+        value = properties[key]
+        return nil unless value
+
+        find_record(object_type, key, value)
+      end
+
+      def find_record(object_type, id_property, value)
+        case object_type
+        when "contacts"
+          find_contact(id_property, value)
+        when "companies", "deals"
+          nil
+        end
+      end
+
+      def find_contact(id_property, value)
+        identifier_type = IDENTIFIER_TYPE_MAP[id_property] || "email_id"
+        path = "/contacts/#{URI.encode_www_form_component(value.to_s)}"
+
+        response = @client.get(
+          path,
+          query: {"identifierType" => identifier_type}
+        )
+
+        if response[:status] == 200 && response[:json].is_a?(Hash)
+          return response[:json]["id"].to_s
+        end
+
+        return nil if response[:status] == 404
+
+        @client.raise_for_error!(response, path: path)
+      end
+
+      def create_record(object_type, properties)
+        path = base_path(object_type)
+
+        body = case object_type
+        when "contacts"
+          build_contact_body(properties)
+        when "companies"
+          build_company_body(properties)
+        when "deals"
+          build_deal_body(properties)
+        end
+
+        response = @client.post(path, body: body)
+        @client.raise_for_error!(response, path: path)
+
+        extract_id(response)
+      end
+
+      def update_record(object_type, record_id, properties)
+        path = "#{base_path(object_type)}/#{record_id}"
+
+        body = case object_type
+        when "contacts"
+          build_contact_body(properties)
+        when "companies"
+          build_company_body(properties)
+        when "deals"
+          build_deal_body(properties)
+        end
+
+        response = if object_type == "contacts"
+          @client.put(path, body: body)
+        else
+          @client.patch(path, body: body)
+        end
+
+        @client.raise_for_error!(response, path: path)
+        true
+      end
+
+      def build_contact_body(properties)
+        email = properties.delete("email")
+        ext_id = properties.delete("ext_id")
+
+        body = {}
+        body[:email] = email if email
+        body[:ext_id] = ext_id if ext_id
+        body[:attributes] = properties if properties.any?
+        body
+      end
+
+      def build_company_body(properties)
+        name = properties.delete("name")
+        body = {}
+        body[:name] = name if name
+        body[:attributes] = properties if properties.any?
+        body
+      end
+
+      def build_deal_body(properties)
+        name = properties.delete("deal_name") || properties.delete("name")
+        body = {}
+        body[:name] = name if name
+        body[:attributes] = properties if properties.any?
+        body
+      end
+
+      def extract_id(response)
+        json = response[:json]
+        return nil unless json.is_a?(Hash)
+
+        (json["id"] || json["contactId"]).to_s
+      end
+
+      def stringify_keys(hash)
+        hash.transform_keys(&:to_s)
+      end
+
+      def validate_string!(name, value)
+        return if value.is_a?(String) && !value.empty?
+
+        raise ArgumentError, "#{name} must be a non-empty String"
+      end
+
+      def validate_object_type!(object_type)
+        return if OBJECT_PATHS.key?(object_type)
+
+        message = [
+          "Unsupported object_type: #{object_type.inspect}.",
+          "Supported: #{OBJECT_PATHS.keys.join(', ')}",
+        ].join(" ")
+        raise ArgumentError, message
+      end
+    end
+  end
+end

--- a/spec/adapters/brevo_adapter_spec.rb
+++ b/spec/adapters/brevo_adapter_spec.rb
@@ -1,0 +1,295 @@
+require "rails_helper"
+
+RSpec.describe Etlify::Adapters::BrevoAdapter do
+  let(:api_key) { "xkeysib-test-key" }
+  let(:http) { instance_double("HttpClient") }
+  let(:adapter) { described_class.new(api_key: api_key, http_client: http) }
+
+  def json_response(status, body = nil)
+    {status: status, body: body ? body.to_json : ""}
+  end
+
+  # ------------------------------------------------------------------ #
+  # Contacts
+  # ------------------------------------------------------------------ #
+
+  describe "#upsert! for contacts" do
+    it "creates a contact when not found", :aggregate_failures do
+      # Search returns 404
+      expect(http).to receive(:request).with(
+        :get, anything, headers: anything, body: nil
+      ).and_return(json_response(404))
+
+      # Create
+      expect(http).to receive(:request).with(
+        :post,
+        "https://api.brevo.com/v3/contacts",
+        headers: hash_including("api-key" => api_key),
+        body: satisfy { |b|
+          json = JSON.parse(b)
+          json["email"] == "john@example.com"
+        }
+      ).and_return(json_response(201, {id: 42}))
+
+      result = adapter.upsert!(
+        object_type: "contacts",
+        payload: {email: "john@example.com", FIRSTNAME: "John"},
+        id_property: "email"
+      )
+      expect(result).to eq("42")
+    end
+
+    it "updates an existing contact", :aggregate_failures do
+      # Search finds contact
+      expect(http).to receive(:request).with(
+        :get, anything, headers: anything, body: nil
+      ).and_return(json_response(200, {id: 99, email: "jane@example.com"}))
+
+      # Update
+      expect(http).to receive(:request).with(
+        :put,
+        "https://api.brevo.com/v3/contacts/99",
+        headers: hash_including("api-key" => api_key),
+        body: anything
+      ).and_return(json_response(204))
+
+      result = adapter.upsert!(
+        object_type: "contacts",
+        payload: {email: "jane@example.com", LASTNAME: "Doe"},
+        id_property: "email"
+      )
+      expect(result).to eq("99")
+    end
+
+    it "updates directly when crm_id is provided" do
+      expect(http).to receive(:request).with(
+        :put,
+        "https://api.brevo.com/v3/contacts/55",
+        headers: anything,
+        body: anything
+      ).and_return(json_response(204))
+
+      result = adapter.upsert!(
+        object_type: "contacts",
+        payload: {FIRSTNAME: "Updated"},
+        crm_id: "55"
+      )
+      expect(result).to eq("55")
+    end
+
+    it "sends identifierType=email_id for email lookups" do
+      expect(http).to receive(:request).with(
+        :get,
+        satisfy { |url| url.include?("identifierType=email_id") },
+        headers: anything,
+        body: nil
+      ).and_return(json_response(404))
+
+      expect(http).to receive(:request).with(
+        :post, anything, headers: anything, body: anything
+      ).and_return(json_response(201, {id: 1}))
+
+      adapter.upsert!(
+        object_type: "contacts",
+        payload: {email: "test@example.com"},
+        id_property: "email"
+      )
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Companies
+  # ------------------------------------------------------------------ #
+
+  describe "#upsert! for companies" do
+    it "creates a company when no crm_id" do
+      expect(http).to receive(:request).with(
+        :post,
+        "https://api.brevo.com/v3/companies",
+        headers: hash_including("api-key" => api_key),
+        body: satisfy { |b|
+          json = JSON.parse(b)
+          json["name"] == "CapSens"
+        }
+      ).and_return(json_response(201, {id: "comp-1"}))
+
+      result = adapter.upsert!(
+        object_type: "companies",
+        payload: {name: "CapSens", industry: "fintech"}
+      )
+      expect(result).to eq("comp-1")
+    end
+
+    it "updates a company when crm_id is provided" do
+      expect(http).to receive(:request).with(
+        :patch,
+        "https://api.brevo.com/v3/companies/comp-1",
+        headers: anything,
+        body: anything
+      ).and_return(json_response(204))
+
+      result = adapter.upsert!(
+        object_type: "companies",
+        payload: {name: "CapSens Updated"},
+        crm_id: "comp-1"
+      )
+      expect(result).to eq("comp-1")
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Deals
+  # ------------------------------------------------------------------ #
+
+  describe "#upsert! for deals" do
+    it "creates a deal when no crm_id" do
+      expect(http).to receive(:request).with(
+        :post,
+        "https://api.brevo.com/v3/crm/deals",
+        headers: anything,
+        body: satisfy { |b|
+          json = JSON.parse(b)
+          json["name"] == "Big Deal"
+        }
+      ).and_return(json_response(201, {id: "deal-1"}))
+
+      result = adapter.upsert!(
+        object_type: "deals",
+        payload: {deal_name: "Big Deal", amount: 10_000}
+      )
+      expect(result).to eq("deal-1")
+    end
+
+    it "updates a deal when crm_id is provided" do
+      expect(http).to receive(:request).with(
+        :patch,
+        "https://api.brevo.com/v3/crm/deals/deal-1",
+        headers: anything,
+        body: anything
+      ).and_return(json_response(204))
+
+      result = adapter.upsert!(
+        object_type: "deals",
+        payload: {deal_name: "Updated Deal"},
+        crm_id: "deal-1"
+      )
+      expect(result).to eq("deal-1")
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Delete
+  # ------------------------------------------------------------------ #
+
+  describe "#delete!" do
+    it "returns true on success" do
+      expect(http).to receive(:request).with(
+        :delete,
+        "https://api.brevo.com/v3/contacts/42",
+        headers: anything,
+        body: nil
+      ).and_return(json_response(204))
+
+      expect(adapter.delete!(object_type: "contacts", crm_id: "42")).to be(true)
+    end
+
+    it "returns false on 404" do
+      expect(http).to receive(:request).with(
+        :delete, anything, headers: anything, body: nil
+      ).and_return(json_response(404, {code: "document_not_found", message: "Not found"}))
+
+      expect(adapter.delete!(object_type: "contacts", crm_id: "999")).to be(false)
+    end
+
+    it "raises on other errors" do
+      expect(http).to receive(:request).with(
+        :delete, anything, headers: anything, body: nil
+      ).and_return(json_response(500, {message: "Internal error"}))
+
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: "42")
+      end.to raise_error(Etlify::ApiError, /Internal error/)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Error mapping
+  # ------------------------------------------------------------------ #
+
+  describe "error mapping" do
+    it "raises Unauthorized on 401" do
+      expect(http).to receive(:request).and_return(
+        json_response(401, {message: "Key not found", code: "unauthorized"})
+      )
+
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: "1")
+      end.to raise_error(Etlify::Unauthorized, /Key not found/)
+    end
+
+    it "raises RateLimited on 429" do
+      expect(http).to receive(:request).and_return(
+        json_response(429, {message: "Too many requests"})
+      )
+
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: "1")
+      end.to raise_error(Etlify::RateLimited, /Too many requests/)
+    end
+
+    it "raises ValidationFailed on 422" do
+      expect(http).to receive(:request).and_return(
+        json_response(422, {message: "Invalid value", code: "invalid_parameter"})
+      )
+
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: "1")
+      end.to raise_error(Etlify::ValidationFailed)
+    end
+
+    it "wraps transport errors into TransportError" do
+      expect(http).to receive(:request).and_raise(StandardError.new("network oops"))
+
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: "1")
+      end.to raise_error(Etlify::TransportError, /network oops/)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Argument validation
+  # ------------------------------------------------------------------ #
+
+  describe "argument validation" do
+    it "raises on unsupported object_type" do
+      expect do
+        adapter.upsert!(object_type: "unknown", payload: {})
+      end.to raise_error(ArgumentError, /Unsupported object_type/)
+    end
+
+    it "raises on missing api_key" do
+      expect do
+        described_class.new(api_key: "")
+      end.to raise_error(ArgumentError, /api_key/)
+    end
+
+    it "raises on missing crm_id for delete" do
+      expect do
+        adapter.delete!(object_type: "contacts", crm_id: nil)
+      end.to raise_error(ArgumentError, /crm_id/)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # Rate limiter
+  # ------------------------------------------------------------------ #
+
+  describe "rate limiter support" do
+    it "delegates rate_limiter to client" do
+      limiter = Etlify::RateLimiter.new(max_requests: 100, period: 3600)
+      adapter.rate_limiter = limiter
+
+      expect(adapter.rate_limiter).to eq(limiter)
+    end
+  end
+end

--- a/spec/adapters/brevo_adapter_spec.rb
+++ b/spec/adapters/brevo_adapter_spec.rb
@@ -95,6 +95,49 @@ RSpec.describe Etlify::Adapters::BrevoAdapter do
         id_property: "email"
       )
     end
+
+    it "sends identifierType=ext_id for ext_id lookups" do
+      expect(http).to receive(:request).with(
+        :get,
+        satisfy { |url| url.include?("identifierType=ext_id") },
+        headers: anything,
+        body: nil
+      ).and_return(json_response(200, {id: 77}))
+
+      expect(http).to receive(:request).with(
+        :put, anything, headers: anything, body: anything
+      ).and_return(json_response(204))
+
+      adapter.upsert!(
+        object_type: "contacts",
+        payload: {ext_id: "user-123", FIRSTNAME: "Alice"},
+        id_property: "ext_id"
+      )
+    end
+
+    it "stringifies symbol keys in payload" do
+      expect(http).to receive(:request).with(
+        :get, anything, headers: anything, body: nil
+      ).and_return(json_response(404))
+
+      expect(http).to receive(:request).with(
+        :post,
+        anything,
+        headers: anything,
+        body: satisfy { |b|
+          json = JSON.parse(b)
+          json["email"] == "sym@example.com" &&
+            json["attributes"].is_a?(Hash) &&
+            json["attributes"].key?("FIRSTNAME")
+        }
+      ).and_return(json_response(201, {id: 10}))
+
+      adapter.upsert!(
+        object_type: "contacts",
+        payload: {email: "sym@example.com", FIRSTNAME: "Sym"},
+        id_property: "email"
+      )
+    end
   end
 
   # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Nouvelles fonctionnalités

- **BrevoAdapter** : adapter complet pour l'API Brevo (ex-Sendinblue) v3 avec `upsert!` et `delete!` pour contacts, companies et deals.
- **Zero dépendance externe** : utilise `Net::HTTP` via le `DefaultHttp` partagé.
- **Rate limiting intégré** : support du `rate_limiter=` sur le `Client` interne, compatible avec le `BatchSyncJob`.
- **Gestion d'erreurs structurée** : mapping HTTP → hiérarchie Etlify (401→Unauthorized, 429→RateLimited, etc.).
- **Pas de `batch_upsert!`** : l'endpoint batch de Brevo est asynchrone (retourne un `processId`), incompatible avec l'interface synchrone. Le `BatchSyncJob` utilise le fallback séquentiel (`Synchronizer.call`).

## Limitations vs HubSpot

| Métrique | HubSpot | Brevo |
|----------|---------|-------|
| Rate limit | 100 req/10s | 100 req/heure (standard) |
| Batch upsert natif | Oui (100 rec/req) | Non (async uniquement) |
| Sync via BatchSyncJob | `BatchSynchronizer` + `batch_upsert!` | Fallback `Synchronizer.call` séquentiel |