### PR TITLE
[v0.11.0] Add per-CRM enabled flag for no-op mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 
+# V0.11.0
+
+- Feat: Add `enabled:` flag to `Etlify::CRM.register` (default `true`). When a CRM is registered with `enabled: false`, all sync and delete calls become a no-op: `Model#crm_sync!` and `Model#crm_delete!` return `true` without enqueuing any job, `Etlify::Synchronizer.call` and `Etlify::Deleter.call` return `:disabled`, `Etlify::BatchSynchronizer.call` returns stats with `disabled: true`, and `Etlify::StaleRecords::BatchSync.call` silently skips disabled CRMs while still processing enabled ones. No adapter call, no write to `crm_synchronisations`. Useful to keep Etlify dormant in development or test environments. New public helper `Etlify::CRM.enabled?(name)` (returns `true` for unknown CRMs as a safe default).
+
 # V0.10.0
 
 - Feat: Extract `DefaultHttp` into a shared class (`lib/etlify/adapters/default_http.rb`) for reuse across adapters.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    etlify (0.10.0)
+    etlify (0.11.0)
       rails (>= 7.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -103,6 +103,40 @@ Etlify.configure do |config|
 end
 ```
 
+### Disabling a CRM
+
+Each CRM registration accepts an `enabled:` flag (default `true`). When set to
+`false`, Etlify behaves as if everything had worked for that CRM but does
+nothing: no adapter call, no job enqueued, no write to `crm_synchronisations`.
+This is handy in development or test environments where you do not want to
+touch the real CRM.
+
+```ruby
+Etlify::CRM.register(
+  :hubspot,
+  adapter: Etlify::Adapters::HubspotV3Adapter.new(
+    access_token: ENV["HUBSPOT_PRIVATE_APP_TOKEN"]
+  ),
+  enabled: Rails.env.production? || Rails.env.staging?,
+  options: { job_class: Etlify::SyncJob }
+)
+
+Etlify::CRM.register(
+  :another_crm,
+  adapter: AnotherAdapter.new,
+  # enabled: true  # default
+)
+```
+
+Behavior when a CRM is disabled:
+
+- `record.hubspot_sync!` and `record.hubspot_delete!` return `true` (truthy, as
+  if everything had succeeded) without enqueuing any job.
+- Internal `Etlify::Synchronizer.call` / `Etlify::Deleter.call` return the
+  symbol `:disabled` (useful for logging and batch statistics).
+- `Etlify::StaleRecords::BatchSync` silently skips the disabled CRM and still
+  processes the enabled ones.
+
 ### Declaring a CRM-synced model
 
 ```ruby

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -1,3 +1,96 @@
+# UPGRADING FROM 0.10.0 -> 0.11.0
+
+## 1. Overview
+
+Etlify 0.11.0 adds an `enabled:` flag on `Etlify::CRM.register` that lets you
+turn a CRM integration into a pure no-op at the process level — typically to
+keep Etlify dormant in development or test environments while leaving other
+CRMs active.
+
+**New features:**
+
+- **`enabled:` option** on `Etlify::CRM.register` (default `true`).
+- **`Etlify::CRM.enabled?(name)`** public helper (returns `true` for unknown
+  CRMs as a safe default).
+- **Model API stays truthy when disabled** — `record.hubspot_sync!` and
+  `record.hubspot_delete!` return `true` so calling code that branches on the
+  return value keeps working unchanged.
+
+---
+
+## 2. Database migrations
+
+No database migration required for this upgrade.
+
+---
+
+## 3. Configuration changes (optional)
+
+Disable a CRM entirely, typically outside of production:
+
+```ruby
+Etlify::CRM.register(
+  :hubspot,
+  adapter: Etlify::Adapters::HubspotV3Adapter.new(
+    access_token: ENV["HUBSPOT_PRIVATE_APP_TOKEN"]
+  ),
+  enabled: Rails.env.production? || Rails.env.staging?,
+  options: { job_class: Etlify::SyncJob }
+)
+
+Etlify::CRM.register(
+  :another_crm,
+  adapter: AnotherAdapter.new,
+  # enabled: true  # default
+)
+```
+
+`enabled:` must be a boolean — anything else raises `ArgumentError` at
+registration time. Omitting the option keeps the previous behaviour
+(`enabled: true`), so existing setups work unchanged.
+
+---
+
+## 4. Behaviour when a CRM is disabled
+
+| Entry point | Return value | Side effects |
+| --- | --- | --- |
+| `record.<crm>_sync!` / `record.crm_sync!` | `true` | No job enqueued, no adapter call |
+| `record.<crm>_delete!` / `record.crm_delete!` | `true` | No adapter call |
+| `Etlify::Synchronizer.call` | `:disabled` | No adapter call, no write to `crm_synchronisations` |
+| `Etlify::Deleter.call` | `:disabled` | No adapter call |
+| `Etlify::BatchSynchronizer.call` | stats hash with `disabled: true`, `skipped: records.size` | No adapter call |
+| `Etlify::StaleRecords::BatchSync.call` | disabled CRMs silently skipped, enabled CRMs processed normally | Stats only reflect enabled CRMs |
+
+Existing `crm_synchronisations` rows are left untouched when a CRM is
+disabled — flipping `enabled:` back to `true` resumes normal sync without any
+extra action (records that became stale in the meantime will be picked up by
+the next `BatchSync`).
+
+---
+
+## 5. QA & testing checklist
+
+- [ ] In a non-production environment, set `enabled: false` on your CRM
+      registration and confirm:
+  - `record.hubspot_sync!` returns `true` and does not enqueue a job.
+  - `record.hubspot_delete!` returns `true`.
+  - `CrmSynchronisation.where(crm_name: "hubspot")` is not written.
+  - No outgoing HTTP request to the CRM (mock adapter or network logs).
+- [ ] In a spec, toggle `enabled` for a single CRM and assert other CRMs
+      keep syncing through `Etlify::StaleRecords::BatchSync`.
+- [ ] Re-enable the CRM and confirm that stale records are synced on the
+      next run.
+
+---
+
+## 6. Backward compatibility
+
+Fully backward-compatible. The default `enabled: true` preserves the
+pre-0.11.0 behaviour for every existing CRM registration.
+
+---
+
 # UPGRADING FROM 0.9.4 -> 0.10.0
 
 ## 1. Overview

--- a/lib/etlify/batch_synchronizer.rb
+++ b/lib/etlify/batch_synchronizer.rb
@@ -21,6 +21,17 @@ module Etlify
     end
 
     def call
+      unless Etlify::CRM.enabled?(@crm_name)
+        return {
+          synced: 0,
+          skipped: @records.size,
+          buffered: 0,
+          not_modified: 0,
+          errors: 0,
+          disabled: true,
+        }
+      end
+
       stats = {synced: 0, skipped: 0, buffered: 0, not_modified: 0, errors: 0}
       ready = []
 

--- a/lib/etlify/crm.rb
+++ b/lib/etlify/crm.rb
@@ -26,7 +26,7 @@ module Etlify
           )
         end
 
-        validate_enabled!(enabled)
+        validate_enabled_type!(enabled)
         validate_rate_limit!(options[:rate_limit]) if options[:rate_limit]
 
         copied_options =
@@ -79,8 +79,8 @@ module Etlify
         )
       end
 
-      def validate_enabled!(enabled)
-        return if enabled.is_a?(TrueClass) || enabled.is_a?(FalseClass)
+      def validate_enabled_type!(enabled)
+        return if [true, false].include?(enabled)
 
         raise ArgumentError, "enabled must be a boolean (true or false)"
       end

--- a/lib/etlify/crm.rb
+++ b/lib/etlify/crm.rb
@@ -4,6 +4,7 @@ module Etlify
       :name,
       :adapter,
       :options,
+      :enabled,
       keyword_init: true
     )
 
@@ -15,7 +16,7 @@ module Etlify
 
       # Public API: register a new CRM
       # Etlify::CRM.register(:my_crm, adapter: MyAdapter.new, options: { job_class: X })
-      def register(name, adapter:, options: {})
+      def register(name, adapter:, enabled: true, options: {})
         key = name.to_sym
 
         if adapter.is_a?(Class)
@@ -25,6 +26,7 @@ module Etlify
           )
         end
 
+        validate_enabled!(enabled)
         validate_rate_limit!(options[:rate_limit]) if options[:rate_limit]
 
         copied_options =
@@ -40,7 +42,8 @@ module Etlify
         registry[key] = RegistryItem.new(
           name: key,
           adapter: adapter,
-          options: copied_options
+          options: copied_options,
+          enabled: enabled
         )
 
         # Install DSL on all classes that already included Etlify::Model
@@ -57,6 +60,13 @@ module Etlify
         registry.keys
       end
 
+      # Public: whether a CRM is enabled. Unknown CRMs default to true
+      # so that this helper is safe to call from any short-circuit site.
+      def enabled?(name)
+        item = registry[name.to_sym]
+        item ? item.enabled : true
+      end
+
       private
 
       def install_rate_limiter!(adapter, rate_limit)
@@ -67,6 +77,12 @@ module Etlify
           max_requests: rate_limit[:max_requests],
           period: rate_limit[:period]
         )
+      end
+
+      def validate_enabled!(enabled)
+        return if enabled.is_a?(TrueClass) || enabled.is_a?(FalseClass)
+
+        raise ArgumentError, "enabled must be a boolean (true or false)"
       end
 
       def validate_rate_limit!(rate_limit)

--- a/lib/etlify/deleter.rb
+++ b/lib/etlify/deleter.rb
@@ -21,6 +21,8 @@ module Etlify
     end
 
     def call
+      return :disabled unless Etlify::CRM.enabled?(crm_name)
+
       line = sync_line
       return :noop unless line&.crm_id.present?
 

--- a/lib/etlify/model.rb
+++ b/lib/etlify/model.rb
@@ -154,6 +154,7 @@ module Etlify
 
     def crm_sync!(crm_name: nil, async: true, job_class: nil)
       raise ArgumentError, "crm_name is required" if crm_name.nil?
+      return true unless Etlify::CRM.enabled?(crm_name)
       return false unless allow_sync_for?(crm_name)
 
       if async
@@ -172,6 +173,7 @@ module Etlify
 
     def crm_delete!(crm_name: nil)
       raise ArgumentError, "crm_name is required" if crm_name.nil?
+      return true unless Etlify::CRM.enabled?(crm_name)
 
       Etlify::Deleter.call(self, crm_name: crm_name)
     end

--- a/lib/etlify/stale_records/batch_sync.rb
+++ b/lib/etlify/stale_records/batch_sync.rb
@@ -53,6 +53,8 @@ module Etlify
           model_count = 0
 
           per_crm.each do |crm, relation|
+            next unless Etlify::CRM.enabled?(crm)
+
             relation.ids.each { |id| pending_pairs[crm] << [model.name, id] }
             model_count += relation.ids.size
           end
@@ -73,6 +75,8 @@ module Etlify
           model_errors = 0
 
           per_crm.each do |crm, relation|
+            next unless Etlify::CRM.enabled?(crm)
+
             processed = process_model_sync(model, relation, crm_name: crm)
             model_count  += processed[:count]
             model_errors += processed[:errors]

--- a/lib/etlify/synchronizer.rb
+++ b/lib/etlify/synchronizer.rb
@@ -34,6 +34,8 @@ module Etlify
     end
 
     def call
+      return :disabled unless Etlify::CRM.enabled?(crm_name)
+
       # Honor sync guard first. If guard returns false, skip the sync.
       guard = conf[:guard]
       unless guard.nil? || guard.call(resource)

--- a/lib/etlify/version.rb
+++ b/lib/etlify/version.rb
@@ -1,3 +1,3 @@
 module Etlify
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/lib/generators/etlify/install/templates/initializer.rb.tt
+++ b/lib/generators/etlify/install/templates/initializer.rb.tt
@@ -4,6 +4,10 @@ Etlify.configure do |config|
   # Register CRM likewise:
     Etlify::CRM.register(
       :hubspot, adapter: Etlify::Adapters::HubspotV3Adapter,
+      # Enable/disable this CRM. When false, all sync/delete calls are
+      # no-op and return true (adapter is never invoked, no DB writes).
+      # Useful to keep Etlify dormant in dev/test. Default: true.
+      # enabled: Rails.env.production? || Rails.env.staging?,
       options: { job_class: Etlify::SyncJob }
     )
     # will provide DSL below for models
@@ -11,6 +15,7 @@ Etlify.configure do |config|
 
     # Etlify::CRM.register(
     #   :another_crm, adapter: Etlify::Adapters::AnotherAdapter,
+    #   # enabled: true,
     #   options: { job_class: Etlify::SyncJob }
     # )
     # will provide DSL below for models

--- a/spec/etlify/batch_synchronizer_spec.rb
+++ b/spec/etlify/batch_synchronizer_spec.rb
@@ -119,5 +119,30 @@ RSpec.describe Etlify::BatchSynchronizer do
       expect(stats[:skipped]).to eq(1)
       expect(stats[:synced]).to eq(0)
     end
+
+    context "when the CRM is disabled" do
+      before do
+        allow(Etlify::CRM).to receive(:enabled?).with(:hubspot)
+                                                .and_return(false)
+      end
+
+      it "returns disabled stats and does not call batch_upsert!",
+         :aggregate_failures do
+        user1 = create_user!(index: 1)
+        user2 = create_user!(index: 2)
+
+        expect(adapter).not_to receive(:batch_upsert!)
+
+        stats = described_class.call([user1, user2], crm_name: :hubspot)
+
+        expect(stats[:disabled]).to be(true)
+        expect(stats[:skipped]).to eq(2)
+        expect(stats[:synced]).to eq(0)
+        expect(stats[:errors]).to eq(0)
+        expect(
+          CrmSynchronisation.where(crm_name: "hubspot").count
+        ).to eq(0)
+      end
+    end
   end
 end

--- a/spec/etlify/crm_registry_spec.rb
+++ b/spec/etlify/crm_registry_spec.rb
@@ -85,10 +85,57 @@ end.new
     expect(zoho.adapter).to eq(a2)
     expect(hubspot.options[:job]).to eq("A")
     expect(zoho.options[:job]).to eq("B")
-    expect(described_class.names).to match_array(%i[hubspot zoho])
+    expect(described_class.names).to match_array([:hubspot, :zoho])
   end
 
   it "fetch raises when CRM is not registered" do
     expect { described_class.fetch(:unknown) }.to raise_error(KeyError)
+  end
+
+  describe "enabled flag" do
+    it "defaults to true when not provided" do
+      described_class.register(:hubspot, adapter: adapter_instance)
+
+      expect(described_class.fetch(:hubspot).enabled).to be(true)
+      expect(described_class.enabled?(:hubspot)).to be(true)
+    end
+
+    it "stores enabled: false and exposes it via enabled?" do
+      described_class.register(
+        :hubspot,
+        adapter: adapter_instance,
+        enabled: false
+      )
+
+      expect(described_class.fetch(:hubspot).enabled).to be(false)
+      expect(described_class.enabled?(:hubspot)).to be(false)
+    end
+
+    it "accepts enabled: true explicitly" do
+      described_class.register(
+        :hubspot,
+        adapter: adapter_instance,
+        enabled: true
+      )
+
+      expect(described_class.enabled?(:hubspot)).to be(true)
+    end
+
+    it "raises when enabled is not a boolean" do
+      expect do
+        described_class.register(
+          :hubspot,
+          adapter: adapter_instance,
+          enabled: "yes"
+        )
+      end.to raise_error(
+        ArgumentError,
+        "enabled must be a boolean (true or false)"
+      )
+    end
+
+    it "returns true for unknown CRMs (safe default)" do
+      expect(described_class.enabled?(:unknown)).to be(true)
+    end
   end
 end

--- a/spec/etlify/deleter_spec.rb
+++ b/spec/etlify/deleter_spec.rb
@@ -71,8 +71,37 @@ RSpec.describe Etlify::Deleter do
     end
   end
 
+  context "when the CRM is disabled" do
+    around do |example|
+      previous = Etlify::CRM.registry[:hubspot]
+      Etlify::CRM.register(
+        :hubspot,
+        adapter: Etlify::Adapters::NullAdapter.new,
+        enabled: false
+      )
+      example.run
+    ensure
+      if previous
+        Etlify::CRM.registry[:hubspot] = previous
+      else
+        Etlify::CRM.registry.delete(:hubspot)
+      end
+    end
+
+    it "returns :disabled and does not call adapter.delete!" do
+      create_line(user, crm_name: "hubspot", crm_id: "crm-123")
+
+      adapter = instance_double(Etlify::Adapters::NullAdapter)
+      allow(Etlify::Adapters::NullAdapter).to receive(:new).and_return(adapter)
+      expect(adapter).not_to receive(:delete!)
+
+      res = described_class.call(user, crm_name: :hubspot)
+      expect(res).to eq(:disabled)
+    end
+  end
+
   context "when adapter.delete! raises" do
-    class FailingDeleteAdapter
+    class FailingDeleteAdapter # rubocop:disable Lint/ConstantDefinitionInBlock
       def delete!(crm_id:, object_type:)
         raise "remote failure"
       end

--- a/spec/etlify/model_spec.rb
+++ b/spec/etlify/model_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Etlify::Model do
         serializer: dummy_serializer,
         crm_object_type: :contact,
         id_property: :external_id,
-        dependencies: %w[company owner],
-        sync_dependencies: %w[company],
+        dependencies: ["company", "owner"],
+        sync_dependencies: ["company"],
         sync_if: ->(r) { r.respond_to?(:active?) ? r.active? : true },
         job_class: "OverrideJob"
       )
@@ -110,8 +110,8 @@ RSpec.describe Etlify::Model do
       expect(conf[:guard]).to be_a(Proc)
       expect(conf[:crm_object_type]).to eq(:contact)
       expect(conf[:id_property]).to eq(:external_id)
-      expect(conf[:dependencies]).to eq(%i[company owner])
-      expect(conf[:sync_dependencies]).to eq(%i[company])
+      expect(conf[:dependencies]).to eq([:company, :owner])
+      expect(conf[:sync_dependencies]).to eq([:company])
       expect(conf[:adapter]).to eq(dummy_adapter)
       expect(conf[:job_class]).to eq("OverrideJob")
     end
@@ -482,6 +482,32 @@ RSpec.describe Etlify::Model do
         .with(inst, crm_name: :hubspot)
       inst.crm_sync!(crm_name: :hubspot, async: false)
     end
+
+    context "when the CRM is disabled" do
+      before do
+        allow(Etlify::CRM).to receive(:enabled?).with(:hubspot)
+                                                .and_return(false)
+      end
+
+      it "returns true without enqueuing anything (async)" do
+        job = Class.new do
+          def self.perform_later(*)
+          end
+        end
+        inst = klass.new
+        allow(inst).to receive(:resolve_job_class_for).and_return(job)
+
+        expect(job).not_to receive(:perform_later)
+        expect(inst.crm_sync!(crm_name: :hubspot, async: true)).to be(true)
+      end
+
+      it "returns true without calling Synchronizer (sync)" do
+        inst = klass.new
+
+        expect(Etlify::Synchronizer).not_to receive(:call)
+        expect(inst.crm_sync!(crm_name: :hubspot, async: false)).to be(true)
+      end
+    end
   end
 
   describe "#crm_delete!" do
@@ -498,6 +524,21 @@ RSpec.describe Etlify::Model do
       inst = klass.new
       expect(Etlify::Deleter).to receive(:call).with(inst, crm_name: :hubspot)
       inst.crm_delete!(crm_name: :hubspot)
+    end
+
+    context "when the CRM is disabled" do
+      before do
+        allow(Etlify::CRM).to receive(:enabled?).with(:hubspot)
+                                                .and_return(false)
+      end
+
+      it "returns true without calling Etlify::Deleter" do
+        klass = build_including_class
+        inst = klass.new
+
+        expect(Etlify::Deleter).not_to receive(:call)
+        expect(inst.crm_delete!(crm_name: :hubspot)).to be(true)
+      end
     end
   end
 
@@ -622,7 +663,7 @@ RSpec.describe Etlify::Model do
       ActiveRecord::Base.connection.drop_table(:etlify_things)
     end
 
-    class EtlifyThing < ApplicationRecord
+    class EtlifyThing < ApplicationRecord # rubocop:disable Lint/ConstantDefinitionInBlock
       self.table_name = "etlify_things"
       include Etlify::Model
     end

--- a/spec/etlify/stale_records/batch_sync_spec.rb
+++ b/spec/etlify/stale_records/batch_sync_spec.rb
@@ -476,6 +476,64 @@ RSpec.describe Etlify::StaleRecords::BatchSync do
     end
   end
 
+  describe "with a disabled CRM" do
+    let(:crm_config) do
+      {
+        hubspot: {
+          adapter: Etlify::Adapters::NullAdapter.new,
+          id_property: "email",
+          crm_object_type: "contacts",
+        },
+        salesforce: {
+          adapter: Etlify::Adapters::NullAdapter.new,
+          id_property: "email",
+          crm_object_type: "contacts",
+        },
+      }
+    end
+
+    before do
+      allow(User).to receive(:etlify_crms).and_return(crm_config)
+      allow(Etlify::CRM).to receive(:enabled?).and_call_original
+      allow(Etlify::CRM).to receive(:enabled?).with(:hubspot)
+                                              .and_return(false)
+    end
+
+    it "skips the disabled CRM in async mode and still enqueues the others",
+       :aggregate_failures do
+      create_user!(index: 1)
+      create_user!(index: 2)
+
+      stats = described_class.call(async: true, batch_size: 10)
+
+      expect(stats[:total]).to eq(2)
+      expect(stats[:per_model]["User"]).to eq(2)
+
+      jobs = aj_enqueued_jobs
+             .select { |j| j[:job] == Etlify::BatchSyncJob }
+      expect(jobs.size).to eq(1)
+      expect(jobs.first[:args][0]).to eq("salesforce")
+    end
+
+    it "skips the disabled CRM in sync mode and still processes the others",
+       :aggregate_failures do
+      called_crms = []
+      allow(Etlify::Synchronizer).to receive(:call) do |_record, crm_name:|
+        called_crms << crm_name
+        :synced
+      end
+
+      create_user!(index: 1)
+      create_user!(index: 2)
+
+      stats = described_class.call(async: false, batch_size: 10)
+
+      expect(stats[:total]).to eq(2)
+      expect(called_crms).to all(eq(:salesforce))
+      expect(called_crms.size).to eq(2)
+    end
+  end
+
   describe "multiple models in async mode" do
     it "aggregates per_model counts across models and CRMs" do
       crm_config = {

--- a/spec/etlify/synchronizer_spec.rb
+++ b/spec/etlify/synchronizer_spec.rb
@@ -462,4 +462,34 @@ RSpec.describe Etlify::Synchronizer do
       expect(line.last_error).to be_nil
     end
   end
+
+  context "when the CRM is disabled" do
+    let(:adapter_instance) { Etlify::Adapters::NullAdapter.new }
+
+    around do |example|
+      previous = Etlify::CRM.registry[:hubspot]
+      Etlify::CRM.register(
+        :hubspot,
+        adapter: adapter_instance,
+        enabled: false
+      )
+      example.run
+    ensure
+      if previous
+        Etlify::CRM.registry[:hubspot] = previous
+      else
+        Etlify::CRM.registry.delete(:hubspot)
+      end
+    end
+
+    it "returns :disabled without touching the adapter or the DB",
+       :aggregate_failures do
+      expect(adapter_instance).not_to receive(:upsert!)
+
+      result = described_class.call(user, crm_name: :hubspot)
+
+      expect(result).to eq(:disabled)
+      expect(sync_lines_for(user).count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds an `enabled:` boolean option to `Etlify::CRM.register` (default `true`). When `false`, the CRM becomes a pure no-op: model `*_sync!` / `*_delete!` return `true`, internal `Synchronizer`/`Deleter` return `:disabled`, `BatchSynchronizer` returns stats with `disabled: true`, and `StaleRecords::BatchSync` silently skips disabled CRMs while still processing the enabled ones.
- No write to `crm_synchronisations` and no adapter call when disabled.
- New public helper `Etlify::CRM.enabled?(name)` (returns `true` for unknown CRMs as a safe default).
- Typical use case: keep Etlify dormant in development or test environments while leaving production untouched.

## Release

- Bump to `v0.11.0`.
- `CHANGELOG.md` and `UPGRADE-GUIDE.md` updated.
- `README.md` gains a `Disabling a CRM` section.

Fully backward-compatible — existing registrations keep the previous behaviour since the default is `enabled: true`.
