### PR TITLE
fix: use polymorphic_name in dependency_has_crm_id? to support STI su…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+- Fix: `Synchronizer#dependency_has_crm_id?` now uses `polymorphic_name` instead of `class.name` when looking up the dependency's `CrmSynchronisation`. Without this, STI subclasses (e.g. `Users::NaturalProfile` whose `polymorphic_name` is `Users::Profile`) were never matched, the dependency was always considered missing, and a new `PendingSync` row was created on every sync attempt — leading to an infinite buffer/flush loop.
+
 # V0.11.0
 
 - Feat: Add `enabled:` flag to `Etlify::CRM.register` (default `true`). When a CRM is registered with `enabled: false`, all sync and delete calls become a no-op: `Model#crm_sync!` and `Model#crm_delete!` return `true` without enqueuing any job, `Etlify::Synchronizer.call` and `Etlify::Deleter.call` return `:disabled`, `Etlify::BatchSynchronizer.call` returns stats with `disabled: true`, and `Etlify::StaleRecords::BatchSync.call` silently skips disabled CRMs while still processing enabled ones. No adapter call, no write to `crm_synchronisations`. Useful to keep Etlify dormant in development or test environments. New public helper `Etlify::CRM.enabled?(name)` (returns `true` for unknown CRMs as a safe default).

--- a/lib/etlify/synchronizer.rb
+++ b/lib/etlify/synchronizer.rb
@@ -132,9 +132,13 @@ module Etlify
 
     # Check if a dependency already has a CRM id, either via CrmSynchronisation
     # (etlified models) or via a direct column like `airtable_id` (legacy models).
+    #
+    # Uses `polymorphic_name` instead of `class.name` because the polymorphic
+    # association on `crm_synchronisations` stores the base class name for STI
+    # subclasses (e.g. "Users::Profile" rather than "Users::NaturalProfile").
     def dependency_has_crm_id?(dep)
       dep_sync = CrmSynchronisation.find_by(
-        resource_type: dep.class.name,
+        resource_type: dep.class.polymorphic_name,
         resource_id: dep.id,
         crm_name: crm_name.to_s
       )

--- a/spec/etlify/synchronizer_spec.rb
+++ b/spec/etlify/synchronizer_spec.rb
@@ -187,6 +187,33 @@ RSpec.describe Etlify::Synchronizer do
       result = described_class.call(user, crm_name: :hubspot)
       expect(result).to eq(:synced)
     end
+
+    it "proceeds to sync when an STI subclass dependency has a crm_id", :aggregate_failures do
+      startup = StartupCompany.create!(name: "CapSens", domain: "capsens.eu")
+      user.update!(company_id: startup.id)
+
+      # CrmSynchronisation rows are stored using polymorphic_name (base class)
+      # for STI subclasses. The dependency lookup must use the same.
+      CrmSynchronisation.create!(
+        crm_name: "hubspot",
+        crm_id: "hubspot-startup-123",
+        resource: startup
+      )
+
+      allow(User).to receive(:etlify_crms).and_return(
+        {
+          hubspot: {
+            adapter: Etlify::Adapters::NullAdapter.new,
+            id_property: "id",
+            crm_object_type: "contacts",
+            sync_dependencies: [:company],
+          },
+        }
+      )
+
+      result = described_class.call(user.reload, crm_name: :hubspot)
+      expect(result).to eq(:synced)
+    end
   end
 
   context "sync_dependencies legacy fallback" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
       end
 
       create_table :companies, force: true do |t|
+        t.string :type
         t.string :name
         t.string :domain
         t.timestamps
@@ -96,6 +97,10 @@ RSpec.configure do |config|
 
     class Company < ApplicationRecord # rubocop:disable Lint/ConstantDefinitionInBlock
       has_many :crm_synchronisations, as: :resource, dependent: :destroy
+    end
+
+    # STI subclass to exercise polymorphic_name behavior in tests.
+    class StartupCompany < Company # rubocop:disable Lint/ConstantDefinitionInBlock
     end
 
     class User < ApplicationRecord # rubocop:disable Lint/ConstantDefinitionInBlock


### PR DESCRIPTION
…bclasses

Bug : dependency_has_crm_id? lookup avec dep.class.name, mais la row est stockée via l'association polymorphic (= polymorphic_name). Sur les STI, mismatch → dep toujours considérée manquante → boucle infinie buffer/flush.

Sur Blast : Trading::Operation dépend du profile (STI Users::NaturalProfile). La crm_synchronisation du profil est stockée avec resource_type = "Users::Profile", mais le lookup cherche "Users::NaturalProfile" → un PendingSync créé puis flush toutes les ~20s en boucle.

Fix : class.name → polymorphic_name. Test ajouté avec une STI subclass.