### PR TITLE
fix: pass returnFieldsByFieldId in AirtableV0Adapter#batch_upsert! to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+- Fix: `AirtableV0Adapter#batch_upsert!` now passes `returnFieldsByFieldId: true` in the `performUpsert` request when `id_property` is an Airtable field ID (e.g. `"fldXXXXXXXXXXXXXX"`). Without this flag, Airtable returned the response fields keyed by name, while `extract_batch_mapping` looked them up by ID, leading to an empty mapping. The records were still created/updated on Airtable, but `BatchSynchronizer` then wrote `crm_id: nil` (with `last_digest` set) on the `crm_synchronisations` row, leaving it stuck (subsequent syncs hit `:not_modified` due to digest match). The flag is added conditionally based on the `fld` prefix to preserve backward compatibility with field-name usage.
+
 # V0.11.0
 
 - Feat: Add `enabled:` flag to `Etlify::CRM.register` (default `true`). When a CRM is registered with `enabled: false`, all sync and delete calls become a no-op: `Model#crm_sync!` and `Model#crm_delete!` return `true` without enqueuing any job, `Etlify::Synchronizer.call` and `Etlify::Deleter.call` return `:disabled`, `Etlify::BatchSynchronizer.call` returns stats with `disabled: true`, and `Etlify::StaleRecords::BatchSync.call` silently skips disabled CRMs while still processing enabled ones. No adapter call, no write to `crm_synchronisations`. Useful to keep Etlify dormant in development or test environments. New public helper `Etlify::CRM.enabled?(name)` (returns `true` for unknown CRMs as a safe default).

--- a/lib/etlify/adapters/airtable_v0_adapter.rb
+++ b/lib/etlify/adapters/airtable_v0_adapter.rb
@@ -91,6 +91,13 @@ module Etlify
         path = @client.base_path(object_type)
         prop_key = id_property.to_s
 
+        # Airtable returns response fields keyed by NAME by default. When the
+        # caller uses field IDs (e.g. "fldXXXXXXXXXXXXXX") for id_property,
+        # we must request the response with field IDs too, otherwise
+        # extract_batch_mapping cannot find the id_property value back and
+        # returns an empty mapping (silently writing crm_id: nil).
+        use_field_ids = prop_key.start_with?("fld")
+
         records.each_slice(BATCH_MAX_SIZE).each_with_object({}) do |slice, mapping|
           body = {
             performUpsert: {
@@ -98,6 +105,7 @@ module Etlify
             },
             records: slice.map { |fields| {fields: stringify_keys(fields)} },
           }
+          body[:returnFieldsByFieldId] = true if use_field_ids
 
           response = @client.patch(path, body: body)
           @client.raise_for_error!(response, path: path)

--- a/lib/etlify/adapters/airtable_v0_adapter.rb
+++ b/lib/etlify/adapters/airtable_v0_adapter.rb
@@ -17,6 +17,7 @@ module Etlify
     #   adapter.batch_delete!(object_type: "tblXXX", crm_ids: ["recAAA", "recBBB"])
     class AirtableV0Adapter
       BATCH_MAX_SIZE = 10
+      AIRTABLE_FIELD_ID_REGEX = /\Afld[A-Za-z0-9]{14}\z/.freeze
 
       def rate_limiter
         @client.rate_limiter
@@ -96,7 +97,7 @@ module Etlify
         # we must request the response with field IDs too, otherwise
         # extract_batch_mapping cannot find the id_property value back and
         # returns an empty mapping (silently writing crm_id: nil).
-        use_field_ids = prop_key.start_with?("fld")
+        use_field_ids = AIRTABLE_FIELD_ID_REGEX.match?(prop_key)
 
         records.each_slice(BATCH_MAX_SIZE).each_with_object({}) do |slice, mapping|
           body = {

--- a/spec/adapters/airtable_v0_adapter_spec.rb
+++ b/spec/adapters/airtable_v0_adapter_spec.rb
@@ -719,6 +719,85 @@ RSpec.describe Etlify::Adapters::AirtableV0Adapter do
       end
     end
 
+    context "when id_property is a field NAME" do
+      it "does NOT request returnFieldsByFieldId, response keys are names" do
+        records = [{Email: "a@b.com", Name: "A"}]
+
+        expect(http).to receive(:request).with(
+          :patch,
+          anything,
+          headers: anything,
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            !json.key?("returnFieldsByFieldId")
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [
+                {
+                  "id" => "recA",
+                  "fields" => {"Email" => "a@b.com"},
+                },
+              ],
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: "Email"
+        )
+
+        expect(result).to eq("a@b.com" => "recA")
+      end
+    end
+
+    context "when id_property is a field ID" do
+      it "requests returnFieldsByFieldId so the response is keyed by field ID" do
+        # Without returnFieldsByFieldId, Airtable returns fields keyed by name
+        # (e.g. "🟣 Mail 1") even when the request uses field IDs. Then
+        # extract_batch_mapping looks up fields["fld..."] => nil and the
+        # mapping is silently empty, causing BatchSynchronizer to write
+        # crm_id: nil with last_digest set, leaving the row stuck forever.
+        email_field_id = "fld0aeED3e0g1qqsx"
+        records = [{email_field_id => "a@b.com"}]
+
+        expect(http).to receive(:request).with(
+          :patch,
+          anything,
+          headers: anything,
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["returnFieldsByFieldId"] == true &&
+              json["performUpsert"]["fieldsToMergeOn"] == [email_field_id]
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: [
+                {
+                  "id" => "recA",
+                  "fields" => {email_field_id => "a@b.com"},
+                },
+              ],
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: email_field_id
+        )
+
+        expect(result).to eq("a@b.com" => "recA")
+      end
+    end
+
     it "raises on invalid arguments", :aggregate_failures do
       expect do
         adapter.batch_upsert!(

--- a/spec/adapters/airtable_v0_adapter_spec.rb
+++ b/spec/adapters/airtable_v0_adapter_spec.rb
@@ -798,6 +798,71 @@ RSpec.describe Etlify::Adapters::AirtableV0Adapter do
       end
     end
 
+    context "with multiple batches and field ID id_property" do
+      it "sends returnFieldsByFieldId on every slice", :aggregate_failures do
+        email_field_id = "fld0aeED3e0g1qqsx"
+        records = (1..12).map { |i| {email_field_id => "u#{i}@test.com"} }
+
+        # First batch: 10 records
+        expect(http).to receive(:request).with(
+          :patch,
+          anything,
+          headers: anything,
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["returnFieldsByFieldId"] == true &&
+              json["records"].size == 10
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (1..10).map do |i|
+                {
+                  "id" => "rec#{i}",
+                  "fields" => {email_field_id => "u#{i}@test.com"},
+                }
+              end,
+            }.to_json,
+          }
+        )
+
+        # Second batch: 2 records
+        expect(http).to receive(:request).with(
+          :patch,
+          anything,
+          headers: anything,
+          body: satisfy do |body|
+            json = JSON.parse(body)
+            json["returnFieldsByFieldId"] == true &&
+              json["records"].size == 2
+          end
+        ).and_return(
+          {
+            status: 200,
+            body: {
+              records: (11..12).map do |i|
+                {
+                  "id" => "rec#{i}",
+                  "fields" => {email_field_id => "u#{i}@test.com"},
+                }
+              end,
+            }.to_json,
+          }
+        )
+
+        result = adapter.batch_upsert!(
+          object_type: table,
+          records: records,
+          id_property: email_field_id
+        )
+
+        expect(result.size).to eq(12)
+        expect(result["u1@test.com"]).to eq("rec1")
+        expect(result["u12@test.com"]).to eq("rec12")
+      end
+    end
+
     it "raises on invalid arguments", :aggregate_failures do
       expect do
         adapter.batch_upsert!(


### PR DESCRIPTION
… fix empty mapping with field ID id_property

## Bug

`AirtableV0Adapter#batch_upsert!` envoyait la requête `performUpsert` sans `returnFieldsByFieldId: true`. Quand l'`id_property` est un field ID (ex: `"fldXXXXXXXXXXXXXX"`), Airtable répondait avec les fields indexés par **nom** alors que `extract_batch_mapping` les lit par **ID** → mapping retourné toujours vide.

Conséquence côté `BatchSynchronizer` : `crm_id` nil mais `last_digest` posé sur la `crm_synchronisations`. Les records côté Airtable étaient bien créés/upsertés, mais etlify n'en récupérait jamais l'ID, et toutes les syncs suivantes tombaient dans `:not_modified` (digest match) → record bloqué éternellement.

Reproduit en staging sur Blast (carte 8938) après bump 0.9.3 → 0.11.0.

## Fix

Ajout conditionnel de `returnFieldsByFieldId: true` dans le body de la requête, basé sur le préfixe `fld` de `id_property`. Préserve la compat avec les usages par field name (existants, README, tests).

## Tests

- Test ajouté pour le cas **field NAME** : vérifie que `returnFieldsByFieldId` n'est PAS dans le body, mapping marche
- Test ajouté pour le cas **field ID** : vérifie que `returnFieldsByFieldId: true` EST dans le body, mapping marche

54/54 specs adapter passent.

## CHANGELOG

Entrée ajoutée sous `# UNRELEASED`.
