### PR TITLE
chore: v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# V0.12.0
 
 This version contains Breaking Changes ⚠️ (please refer to `UPGRADE-GUIDE.md`)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    etlify (0.11.3)
+    etlify (0.12.0)
       rails (>= 7.0)
 
 GEM

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -1,4 +1,4 @@
-# UPGRADING FROM 0.11.3 -> UNRELEASED
+# UPGRADING FROM 0.11.3 -> 0.12.0
 
 ## 1. Overview
 

--- a/lib/etlify/version.rb
+++ b/lib/etlify/version.rb
@@ -1,3 +1,3 @@
 module Etlify
-  VERSION = "0.11.3"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
## Release v0.12.0

Version bump + doc headers for the v0.12.0 release (breaking changes ⚠️).

- `lib/etlify/version.rb`: `0.11.3` → `0.12.0`
- `CHANGELOG.md`: `# UNRELEASED` → `# V0.12.0`
- `UPGRADE-GUIDE.md`: header now targets `0.11.3 -> 0.12.0`
- `Gemfile.lock`: refreshed (`etlify (0.12.0)`)

See `CHANGELOG.md` for the full list of changes and `UPGRADE-GUIDE.md` for the migration path (`id_property` → `match_by`, custom adapters, expected one-off digest re-sync).

Test suite: 443 examples, 0 failures.